### PR TITLE
Revise `unwrap_recursive` family

### DIFF
--- a/doc/rvariant.adoc
+++ b/doc/rvariant.adoc
@@ -22,9 +22,9 @@ Yaito Kakeyama; Nana Sakisaka
 :exposition-only: pass:quotes[[.exposition-only]#exposition only#]
 :bad-variant-access: pass:quotes,macros[https://eel.is/c++draft/variant.bad.access[`std::bad_variant_access`]]
 
-:unwrap_recursive_t: <<rvariant.recursive.helper,unwrap_recursive_t>>
+:unwrap_recursive_type: <<rvariant.recursive.helper,unwrap_recursive_type>>
+:unwrap_recursive: pass:quotes[xref:#rvariant.recursive.helper[unwrap_recursive]]
 :recursive_wrapper: pass:macros[xref:#rvariant.recursive[recursive_wrapper]]
-:UNWRAP_RECURSIVE: pass:quotes[_xref:#rvariant.recursive.helper[UNWRAP_RECURSIVE]_]
 
 :subset_of: <<rvariant.flex,rvariant_set::subset_of>>
 :equivalent_to: <<rvariant.flex,rvariant_set::equivalent_to>>
@@ -51,7 +51,7 @@ expr.visit(temp_ns::overloaded{
 === Supported Environments
 * GCC 14
 * Clang 21-22 (lib{cxx})
-* MSVC (2022)
+* MSVC 2022 and 2026
 * {cpp}23 and {cpp}26
 
 
@@ -380,9 +380,8 @@ template<class T, class Allocator>
   /* constexpr */ std::size_t hash_value(recursive_wrapper<T, Allocator> const&);
 
 // <<rvariant.recursive.helper,[rvariant.recursive.helper]>>, pass:quotes[`recursive_wrapper`] helper classes
-template<class T> struct unwrap_recursive;
-template<class T, class Allocator> struct unwrap_recursive<recursive_wrapper<T, Allocator>>;
-template<class T> using unwrap_recursive_t = typename unwrap_recursive<T>::type;
+template<class T> using unwrap_recursive_type = {see-below};
+template<class T> constexpr auto&& unwrap_recursive(T&& o) noexcept;
 
 // <<rvariant.pack,[rvariant.pack]>>, pack manipulation and deduping
 template<template<class...> class TT, class A, class B>
@@ -516,7 +515,7 @@ rvariant<
 ----
 --
 
-* Let `VT~_i_~` denote `{recursive_wrapper}<T~_i_~, A>` (for any type `A`) if such a specialization occurs anywhere in `Ts\...`; otherwise, let `VT~_i_~` denote `T~_i_~`. Let `U~_j_~` denote the _j_^th^ type of the template parameter pack having the name `Us` on each flexibility-related functions. [.underline]#The _corresponding alternative_ for `rvariant` is the first type for which `std::is_same_v<{unwrap_recursive_t}<VT~_i_~>, {unwrap_recursive_t}<U~_j_~>>` is `true`#.
+* Let `VT~_i_~` denote `{recursive_wrapper}<T~_i_~, A>` (for any type `A`) if such a specialization occurs anywhere in `Ts\...`; otherwise, let `VT~_i_~` denote `T~_i_~`. Let `U~_j_~` denote the _j_^th^ type of the template parameter pack having the name `Us` on each flexibility-related functions. [.underline]#The _corresponding alternative_ for `rvariant` is the first type for which `std::is_same_v<{unwrap_recursive_type}<VT~_i_~>, {unwrap_recursive_type}<U~_j_~>>` is `true`#.
 
 
 [[rvariant.ctor]]
@@ -562,7 +561,7 @@ include::_std-variant-proxy.adoc[]
 
 * [.candidate]#4)# _Generic constructor_. Equivalent to the `std::variant` counterpart, ^https://eel.is/c++draft/variant.ctor[[spec\]]^ except:
 +
-*_Postconditions:_* `holds_alternative[.underline]##<{unwrap_recursive_t}<T~_j_~>>##(*this)` is `true`.
+*_Postconditions:_* `holds_alternative[.underline]##<{unwrap_recursive_type}<T~_j_~>>##(*this)` is `true`.
 
 * [.candidate]#5)# *_Mandates:_* [.underline]#`T` is not a specialization of `{recursive_wrapper}`#.
 +
@@ -572,7 +571,7 @@ include::_std-variant-proxy.adoc[]
 +
 --
 [none]
-** -- There is exactly one occurrence of `T` in [.underline]#`{unwrap_recursive_t}<Ts>\...`# and
+** -- There is exactly one occurrence of `T` in [.underline]#`{unwrap_recursive_type}<Ts>\...`# and
 ** -- `std::is_constructible_v<[.underline]##VT##, Args\...>` is `true`.
 --
 +
@@ -592,7 +591,7 @@ include::_std-variant-proxy.adoc[]
 +
 --
 [none]
-** -- There is exactly one occurrence of `T` in [.underline]#`{unwrap_recursive_t}<Ts>\...`# and
+** -- There is exactly one occurrence of `T` in [.underline]#`{unwrap_recursive_type}<Ts>\...`# and
 ** -- `std::is_constructible_v<[.underline]##VT##, std::initializer_list<U>&, Args\...>` is `true`.
 --
 +
@@ -617,7 +616,7 @@ include::_std-variant-proxy.adoc[]
 [none]
 ** -- `std::is_same_v<rvariant<Us\...>, rvariant>` is `false`, and
 ** -- [.underline]#`{subset_of}<rvariant<Us\...>, rvariant>` is `true`, and#
-** -- [.underline]#`std::disjunction_v<std::is_same<rvariant<Us\...>, {unwrap_recursive_t}<Ts>>\...>` is `false`, and#
+** -- [.underline]#`std::disjunction_v<std::is_same<rvariant<Us\...>, {unwrap_recursive_type}<Ts>>\...>` is `false`, and#
 ** -- [.underline]#`std::is_constructible_v<VT~_i_~, U~_j_~ const&>` is `true` for all _j_.#
 --
 +
@@ -641,7 +640,7 @@ include::_std-variant-proxy.adoc[]
 [none]
 ** -- `std::is_same_v<rvariant<Us\...>, rvariant>` is `false`, and
 ** -- `{subset_of}<rvariant<Us\...>, rvariant>` is `true`, and
-** -- `std::disjunction_v<std::is_same<rvariant<Us\...>, {unwrap_recursive_t}<Ts>>\...>` is `false`, and
+** -- `std::disjunction_v<std::is_same<rvariant<Us\...>, {unwrap_recursive_type}<Ts>>\...>` is `false`, and
 ** -- `std::is_constructible_v<VT~_i_~, [.underline]#U~_j_~&&#>` is `true` for all _j_.
 --
 +
@@ -699,7 +698,7 @@ include::_std-variant-proxy.adoc[]
 
 * [.candidate]#3)# _Generic assignment operator_. Equivalent to the `std::variant` counterpart, ^https://eel.is/c++draft/variant.assign[[spec\]]^ except:
 +
-*_Postconditions:_* `holds_alternative[.underline]##<{unwrap_recursive_t}<T~_j_~>>##(*this)` is `true`, with `T~_j_~` selected by the imaginary function overload resolution described above.
+*_Postconditions:_* `holds_alternative[.underline]##<{unwrap_recursive_type}<T~_j_~>>##(*this)` is `true`, with `T~_j_~` selected by the imaginary function overload resolution described above.
 
 * [.candidate]#4)# _Flexible copy assignment operator_.
 +
@@ -711,7 +710,7 @@ include::_std-variant-proxy.adoc[]
 [none]
 ** -- `std::is_same_v<rvariant<Us\...>, rvariant>` is `false`, and
 ** -- [.underline]#`{subset_of}<rvariant<Us\...>, rvariant>` is `true`, and#
-** -- [.underline]#`std::disjunction_v<std::is_same<rvariant<Us\...>, {unwrap_recursive_t}<Ts>>\...>` is `false`, and#
+** -- [.underline]#`std::disjunction_v<std::is_same<rvariant<Us\...>, {unwrap_recursive_type}<Ts>>\...>` is `false`, and#
 ** -- [.underline]#`std::is_constructible_v<VT~_i_~, U~_j_~ const&> && std::is_assignable_v<VT~_i_~&, U~_j_~ const&>` is `true` for all _j_.#
 --
 +
@@ -722,7 +721,7 @@ include::_std-variant-proxy.adoc[]
 ** -- If neither `*this` nor `rhs` holds a value, there is no effect.
 ** -- Otherwise, if `*this` holds a value but `rhs` does not, destroys the value contained in `*this` and sets `*this` to not hold a value.
 ** -- Otherwise, if `rhs` holds a value but `*this` does not, initializes `rvariant` to hold [.underline]#`VT~_i_~` (with _i_ being the index of the alternative corresponding to that of `rhs`)# and direct-initializes the contained value with [.underline]#`_GET_<__j__>(rhs)`.#
-** -- Otherwise, if [.underline]#`std::is_same_v<{unwrap_recursive_t}<T~_i_~>, {unwrap_recursive_t}<U~_j_~>>` is `true`#, assigns [.underline]#`_GET_<__j__>(rhs)`# to the value contained in `*this`. [.underline]#(_Note:_ the left hand side is `T~_i_~`, _not_ `VT~_i_~`. This ensures that the existing storage is reused even for `rvariant` with duplicate corresponding alternatives; i.e., `index()` is unchanged.)#
+** -- Otherwise, if [.underline]#`std::is_same_v<{unwrap_recursive_type}<T~_i_~>, {unwrap_recursive_type}<U~_j_~>>` is `true`#, assigns [.underline]#`_GET_<__j__>(rhs)`# to the value contained in `*this`. [.underline]#(_Note:_ the left hand side is `T~_i_~`, _not_ `VT~_i_~`. This ensures that the existing storage is reused even for `rvariant` with duplicate corresponding alternatives; i.e., `index()` is unchanged.)#
 ** -- Otherwise, if either `std::is_nothrow_constructible_v<VT~_i_~, U~_j_~ const&>` is `true` or `std::is_nothrow_move_constructible_v<VT~_i_~>` is `false`, equivalent to `emplace[.underline]##<VT~_i_~>##(_GET_<__j__>(rhs))`.
 ** -- Otherwise, equivalent to `emplace<VT~_i_~>([.underline]##VT~_i_~##(_GET_<__j__>(rhs)))`.
 --
@@ -743,7 +742,7 @@ include::_std-variant-proxy.adoc[]
 [none]
 ** -- [.underline]#`std::is_same_v<rvariant<Us\...>, rvariant>` is `false`,#
 ** -- [.underline]#`{subset_of}<rvariant<Us\...>, rvariant>` is `true`, and#
-** -- [.underline]#`std::disjunction_v<std::is_same<rvariant<Us\...>, {unwrap_recursive_t}<Ts>>\...>` is `false`, and#
+** -- [.underline]#`std::disjunction_v<std::is_same<rvariant<Us\...>, {unwrap_recursive_type}<Ts>>\...>` is `false`, and#
 ** -- [.underline]#`std::is_constructible_v<VT~_i_~, U~_j_~&&> && std::is_assignable_v<VT~_i_~&, U~_j_~&&>` is `true` for all _j_.#
 --
 +
@@ -754,7 +753,7 @@ include::_std-variant-proxy.adoc[]
 ** -- If neither `*this` nor `rhs` holds a value, there is no effect.
 ** -- Otherwise, if `*this` holds a value but `rhs` does not, destroys the value contained in `*this` and sets `*this` to not hold a value.
 ** -- Otherwise, if `rhs` holds a value but `*this` does not, initializes `rvariant` to hold [.underline]#`VT~_i_~` (with _i_ being the index of the alternative corresponding to that of `rhs`)# and direct-initializes the contained value with [.underline]#`_GET_<__j__>(std::move(rhs))`.#
-** -- Otherwise, if [.underline]#`std::is_same_v<{unwrap_recursive_t}<T~_i_~>, {unwrap_recursive_t}<U~_j_~>>` is `true`#, assigns [.underline]#`_GET_<__j__>(std::move(rhs))`# to the value contained in `*this`. [.underline]#(_Note:_ the left hand side is `T~_i_~`, _not_ `VT~_i_~`. This ensures that the existing storage is reused even for `rvariant` with duplicate corresponding alternatives; i.e., `index()` is unchanged.)#
+** -- Otherwise, if [.underline]#`std::is_same_v<{unwrap_recursive_type}<T~_i_~>, {unwrap_recursive_type}<U~_j_~>>` is `true`#, assigns [.underline]#`_GET_<__j__>(std::move(rhs))`# to the value contained in `*this`. [.underline]#(_Note:_ the left hand side is `T~_i_~`, _not_ `VT~_i_~`. This ensures that the existing storage is reused even for `rvariant` with duplicate corresponding alternatives; i.e., `index()` is unchanged.)#
 ** -- Otherwise, equivalent to `emplace[.underline]##<VT~_i_~>##(_GET_<__j__>(std::move(rhs)))`.
 --
 +
@@ -790,31 +789,31 @@ constexpr variant_alternative_t<I, rvariant<Ts...>>&
 +
 *_Mandates:_* [.underline]#`T` is not a specialization of `{recursive_wrapper}`.#
 +
-*_Constraints:_* `std::is_constructible_v<[.underline]##VT##, Args\...>` is `true`, and `T` occurs exactly once in [.underline]#`{unwrap_recursive_t}<Ts>`#.
+*_Constraints:_* `std::is_constructible_v<[.underline]##VT##, Args\...>` is `true`, and `T` occurs exactly once in [.underline]#`{unwrap_recursive_type}<Ts>`#.
 +
 *_Effects:_* Equivalent to: +
 pass:quotes[&nbsp;&nbsp;]`return emplace<__I__>(std::forward<Args>(args)\...);` +
-where `_I_` is the zero-based index of `T` in [.underline]#`{unwrap_recursive_t}<Ts>`#.
+where `_I_` is the zero-based index of `T` in [.underline]#`{unwrap_recursive_type}<Ts>`#.
 
 * [.candidate]#2)# [.underline]#Let `VT` denote `{recursive_wrapper}<T, A>` (for any type `A`) if such a specialization occurs anywhere in `Ts\...`; otherwise, let `VT` denote `T`.#
 +
 *_Mandates:_* [.underline]#`T` is not a specialization of `{recursive_wrapper}`.#
 +
-*_Constraints:_* `std::is_constructible_v<[.underline]##VT##, std::initializer_list<U>&, Args\...>` is `true`, and `T` occurs exactly once in [.underline]#`{unwrap_recursive_t}<Ts>`#.
+*_Constraints:_* `std::is_constructible_v<[.underline]##VT##, std::initializer_list<U>&, Args\...>` is `true`, and `T` occurs exactly once in [.underline]#`{unwrap_recursive_type}<Ts>`#.
 +
 *_Effects:_* Equivalent to: +
 pass:quotes[&nbsp;&nbsp;]`return emplace<__I__>(il, std::forward<Args>(args)\...);` +
-where `_I_` is the zero-based index of `T` in [.underline]#`{unwrap_recursive_t}<Ts>`#.
+where `_I_` is the zero-based index of `T` in [.underline]#`{unwrap_recursive_type}<Ts>`#.
 
 * [.candidate]#3)# Equivalent to the `std::variant` counterpart, ^https://eel.is/c++draft/variant.mod[[spec\]]^ except:
 +
-*_Returns:_* [.underline]#Let `o` denote# a reference to the new contained value. [.underline]#Returns `{UNWRAP_RECURSIVE}(o)`.#
+*_Returns:_* [.underline]#Let `o` denote# a reference to the new contained value. [.underline]#Returns `{unwrap_recursive}(o)`.#
 +
 *_Remarks:_* [.underline]#If `T~_I_~` is a specialization of `{recursive_wrapper}`, this function is permitted to construct an intermediate variable `tmp` as if by passing `std::forward<Args>(args)\...` to ``T~_I_~``'s constructor. Then `rvariant` direct-non-list-initializes the contained value of `T~_I_~` with the argument `std::move(tmp)`. (_Note:_ This allows optimization where `rvariant` can be assumed to become never valueless on certain cases.)#
 
 * [.candidate]#4)# Equivalent to the `std::variant` counterpart, ^https://eel.is/c++draft/variant.mod[[spec\]]^ except:
 +
-*_Returns:_* [.underline]#Let `o` denote# a reference to the new contained value. [.underline]#Returns `{UNWRAP_RECURSIVE}(o)`.#
+*_Returns:_* [.underline]#Let `o` denote# a reference to the new contained value. [.underline]#Returns `{unwrap_recursive}(o)`.#
 +
 *_Remarks:_* [.underline]#If `T~_I_~` is a specialization of `{recursive_wrapper}`, this function is permitted to construct an intermediate variable `tmp` as if by passing `il, std::forward<Args>(args)\...` to ``T~_I_~``'s constructor. Then `rvariant` direct-non-list-initializes the contained value of `T~_I_~` with the argument `std::move(tmp)`. (_Note:_ This allows optimization where `rvariant` can be assumed to become never valueless on certain cases.)#
 
@@ -930,7 +929,7 @@ struct variant_alternative<I, rvariant<Ts...>>;pass:quotes[[.candidate\]#// 2#]
 * [.candidate]#1)#
 include::_std-variant-proxy.adoc[]
 
-* [.candidate]#2)# The member typedef `type` denotes [.underline]#`{unwrap_recursive_t}<T~_I_~>`#.
+* [.candidate]#2)# The member typedef `type` denotes [.underline]#`{unwrap_recursive_type}<T~_I_~>`#.
 +
 *_Mandates:_* `I < sizeof\...(Ts)`.
 
@@ -967,7 +966,7 @@ concept equivalent_to = subset_of<W, V> && subset_of<V, W>;
 +
 [none]
 ** -- `T` is the same type as `U` or,
-** -- `{unwrap_recursive_t}<T>` is the same type as `U`.
+** -- `{unwrap_recursive_type}<T>` is the same type as `U`.
 
 
 [[rvariant.get]]
@@ -984,9 +983,9 @@ constexpr bool holds_alternative(rvariant<Ts...> const& v) noexcept;
 ----
 
 [.candidates]
-* [.candidate]#{empty}# *_Mandates:_* The type `T` occurs exactly once in [.underline]#`{unwrap_recursive_t}<Ts>`#.
+* [.candidate]#{empty}# *_Mandates:_* The type `T` occurs exactly once in [.underline]#`{unwrap_recursive_type}<Ts>`#.
 +
-*_Returns:_* `true` if `v.index()` is equal to the zero-based index of `T` in [.underline]#`{unwrap_recursive_t}<Ts>`#.
+*_Returns:_* `true` if `v.index()` is equal to the zero-based index of `T` in [.underline]#`{unwrap_recursive_type}<Ts>`#.
 +
 *_Remarks:_* [.underline]#This function is defined as deleted if `T` is a specialization of `{recursive_wrapper}`.#
 
@@ -1011,7 +1010,7 @@ constexpr {see-below} const&& pass:quotes[_GET_](rvariant<Ts...> const&& v); // 
 +
 *_Preconditions:_* `v.index()` is `I`.
 +
-*_Returns:_* [.underline]#`o`, where `o` denotes a reference to the object stored in `v`, if the type of the expression's receiver is a specialization of `{recursive_wrapper}`; otherwise, returns `{UNWRAP_RECURSIVE}(o)`#.
+*_Returns:_* [.underline]#`o`, where `o` denotes a reference to the object stored in `v`, if the type of the expression's receiver is a specialization of `{recursive_wrapper}`; otherwise, returns `{unwrap_recursive}(o)`#.
 
 
 [,cpp,subs="+macros,+attributes"]
@@ -1040,7 +1039,7 @@ constexpr variant_alternative_t<I, rvariant<Ts...>> const&&
 [.candidates]
 * [.candidate]#{empty}# *_Mandates:_* `I < sizeof\...(Ts)`.
 +
-*_Effects:_* If `v.index()` is `I`, returns [.underline]#`{UNWRAP_RECURSIVE}(o)`, where `o` denotes a reference to the object stored in the `rvariant`#. Otherwise, throws an exception of type {bad-variant-access}.
+*_Effects:_* If `v.index()` is `I`, returns [.underline]#`{unwrap_recursive}(o)`, where `o` denotes a reference to the object stored in the `rvariant`#. Otherwise, throws an exception of type {bad-variant-access}.
 
 
 [,cpp,subs="+macros,+attributes"]
@@ -1056,9 +1055,9 @@ template<class T, class... Ts> constexpr T const&& get(rvariant<Ts...> const&& v
 ----
 
 [.candidates]
-* [.candidate]#{empty}# *_Mandates:_* The type `T` occurs exactly once in [.underline]#`{unwrap_recursive_t}<Ts>`#.
+* [.candidate]#{empty}# *_Mandates:_* The type `T` occurs exactly once in [.underline]#`{unwrap_recursive_type}<Ts>`#.
 +
-*_Effects:_* [.underline]#Let `VT` denote the type of the alternative held by `v`. If `{unwrap_recursive_t}<VT>` is the same type as `T`#, returns [.underline]#`{UNWRAP_RECURSIVE}(o)`, where `o` denotes a reference to the object stored in the `rvariant`#. Otherwise, throws an exception of type {bad-variant-access}.
+*_Effects:_* [.underline]#Let `VT` denote the type of the alternative held by `v`. If `{unwrap_recursive_type}<VT>` is the same type as `T`#, returns [.underline]#`{unwrap_recursive}(o)`, where `o` denotes a reference to the object stored in the `rvariant`#. Otherwise, throws an exception of type {bad-variant-access}.
 +
 *_Remarks:_* [.underline]#This function is defined as deleted if `T` is a specialization of `{recursive_wrapper}`.#
 
@@ -1081,7 +1080,7 @@ constexpr std::add_pointer_t<variant_alternative_t<I, rvariant<Ts...>> const>
 [.candidates]
 * [.candidate]#1-2)# *_Mandates:_* `I < sizeof\...(Ts)`.
 +
-*_Returns:_* A pointer to the value [.underline]#denoted by `{UNWRAP_RECURSIVE}(o)`, where `o` denotes a reference to the object stored in the `rvariant`#, if `v != nullptr` and `v\->index() == I`. Otherwise, returns `nullptr`.
+*_Returns:_* A pointer to the value [.underline]#denoted by `{unwrap_recursive}(o)`, where `o` denotes a reference to the object stored in the `rvariant`#, if `v != nullptr` and `v\->index() == I`. Otherwise, returns `nullptr`.
 
 
 [,cpp,subs="+macros,+attributes"]
@@ -1100,9 +1099,9 @@ constexpr std::add_pointer_t<T const>
 ----
 
 [.candidates]
-* [.candidate]#1-2)# *_Mandates:_* The type `T` occurs exactly once in [.underline]#`{unwrap_recursive_t}<Ts>`#.
+* [.candidate]#1-2)# *_Mandates:_* The type `T` occurs exactly once in [.underline]#`{unwrap_recursive_type}<Ts>`#.
 +
-*_Effects:_* Equivalent to: `return get_if<__i__>(v);` with _i_ being the zero-based index of `T` in [.underline]#`{unwrap_recursive_t}<Ts>`#.
+*_Effects:_* Equivalent to: `return get_if<__i__>(v);` with _i_ being the zero-based index of `T` in [.underline]#`{unwrap_recursive_type}<Ts>`#.
 +
 *_Remarks:_* [.underline]#This function is defined as deleted if `T` is a specialization of `{recursive_wrapper}`.#
 
@@ -1135,7 +1134,7 @@ constexpr R visit(this Self&& self, Visitor&& vis);pass:quotes[[.candidate\]#// 
 * [.candidate]#1-2)# Equivalent to the `std::variant` counterpart ^https://eel.is/c++draft/variant.visit[[spec\]]^, except that:
 +
 [none]
-** -- `_GET_<__m__>(std::forward<V>(vars))` is replaced with `{UNWRAP_RECURSIVE}(_GET_<__m__>(std::forward<V>(vars)))`.
+** -- `_GET_<__m__>(std::forward<V>(vars))` is replaced with `{unwrap_recursive}(_GET_<__m__>(std::forward<V>(vars)))`.
 
 * [.candidate]#3-4)# Equivalent to the `std::variant` counterpart ^https://eel.is/c++draft/variant.visit[[spec\]]^, except that it forwards to `temp_ns::visit` instead of `std::visit`.
 
@@ -1216,13 +1215,13 @@ std::ostream& operator<<(std::ostream& os, rvariant<Ts...> const& v);pass:quotes
 ** -- the expression `os << val` is well-formed and has the type `std::ostream&`, and
 ** -- the corresponding overload is found solely via ADL.
 
-* [.candidate]#2)# *_Constraints:_* `_ADL-ostreamable_<{unwrap_recursive_t}<T~_i_~>>` is `true` for all _i_.
+* [.candidate]#2)# *_Constraints:_* `_ADL-ostreamable_<{unwrap_recursive_type}<T~_i_~>>` is `true` for all _i_.
 +
 *_Effects:_* Behaves as a formatted output function (https://eel.is/c++draft/ostream.formatted.reqmts[[ostream.formatted.reqmts\]]) of `os`, except that:
 +
 --
 [none]
-** -- the output is done as if by calling `os << {UNWRAP_RECURSIVE}(_GET_<__i__>(v))` (with _i_ being `v.index()`), and
+** -- the output is done as if by calling `os << {unwrap_recursive}(_GET_<__i__>(v))` (with _i_ being `v.index()`), and
 ** -- any exception of type `std::bad_variant_access`, whether thrown directly (i.e., due to `v` being valueless) or indirectly (i.e., by a nested call to an alternative's output function), is propagated without regard to the value of `os.exceptions()` and without turning on `std::ios_base::badbit` in the error state of `os`.
 --
 +
@@ -1240,12 +1239,12 @@ std::ostream& operator<<(std::ostream& os, rvariant<Ts...> const& v);pass:quotes
 [none]
 * Let `v` denote an object of `rvariant`, and let `proxy` denote an object of `{variant-format-proxy}`.
 
-* The specialization `std::formatter<::temp_ns::rvariant<Ts\...>, charT>` (for arbitrary `charT`) is enabled if and only if `std::formattable<{unwrap_recursive_t}<Ts~_i_~>, charT>` is `true` for all _i_, with the following characteristics:
+* The specialization `std::formatter<::temp_ns::rvariant<Ts\...>, charT>` (for arbitrary `charT`) is enabled if and only if `std::formattable<{unwrap_recursive_type}<Ts~_i_~>, charT>` is `true` for all _i_, with the following characteristics:
 +
 [none]
 ** -- The format specifier must be empty, otherwise `std::format_error` is thrown, and
 ** -- if `v.valueless_by_exception()` is `true`, `std::bad_variant_access` is thrown, and
-** -- the output is done as if by calling `std::format_to(fmt_ctx.out(), _paren_, {UNWRAP_RECURSIVE}(_GET_<v.index()>(v)))`, with `_paren_` being a string literal `"{}"` interpreted on the target character type.
+** -- the output is done as if by calling `std::format_to(fmt_ctx.out(), _paren_, {unwrap_recursive}(_GET_<v.index()>(v)))`, with `_paren_` being a string literal `"{}"` interpreted on the target character type.
 ** _Example:_
 +
 [,cpp,subs="+macros,+attributes"]
@@ -1258,14 +1257,14 @@ std::println("{}", temp_ns::rvariant<int, double>(42)); // prints pass:quotes[`4
 [none]
 ** -- `std::remove_cvref_t<VFormat>` is a specialization of `{variant-format-string}`, and
 ** -- `std::remove_cvref_t<Variant>` is a specialization of `rvariant`, and
-** -- `std::formattable<{unwrap_recursive_t}<Ts~_i_~>, charT>` is `true` for all _i_, with `Ts` being the template parameter pack of cv-unqualified non-reference type for `Variant`.
+** -- `std::formattable<{unwrap_recursive_type}<Ts~_i_~>, charT>` is `true` for all _i_, with `Ts` being the template parameter pack of cv-unqualified non-reference type for `Variant`.
 
 * It has the following characteristics:
 +
 [none]
 ** -- The format specifier must be empty, otherwise `std::format_error` is thrown, and
 ** -- if `v.valueless_by_exception()` is `true`, `std::bad_variant_access` is thrown, and
-** -- the output is done as if by calling `std::format_to(fmt_ctx.out(), proxy.v_fmt(std::in_place_type<Ts\...[proxy.v.index()]>), {UNWRAP_RECURSIVE}(_GET_<proxy.v.index()>(proxy.v)))`, with `Ts` being the template parameter pack of the cv-unqualified non-reference type of `proxy.v`.
+** -- the output is done as if by calling `std::format_to(fmt_ctx.out(), proxy.v_fmt(std::in_place_type<Ts\...[proxy.v.index()]>), {unwrap_recursive}(_GET_<proxy.v.index()>(proxy.v)))`, with `Ts` being the template parameter pack of the cv-unqualified non-reference type of `proxy.v`.
 ** _Example:_
 +
 [,cpp,subs="+macros,+attributes"]
@@ -1453,35 +1452,35 @@ _Note 2:_ It is currently unknown whether the recursive instantiation scenario d
 
 
 [[rvariant.recursive.helper]]
-== `recursive_wrapper` helper classes [.slug]##<<rvariant.recursive.helper,[rvariant.recursive.helper]>>##
+== `recursive_wrapper` helper utilities [.slug]##<<rvariant.recursive.helper,[rvariant.recursive.helper]>>##
 
 [,cpp,subs="+macros,+attributes"]
 ----
 namespace temp_ns {
 
 template<class T>
-struct unwrap_recursive
-{
-  using type = T;
-};
-
-template<class T, class Allocator>
-struct unwrap_recursive<recursive_wrapper<T, Allocator>>
-{
-  using type = T;
-};
+using unwrap_recursive_type = {see-below};
 
 } // temp_ns
 ----
 
+[.candidates]
+* [.candidate]#{empty}# Denotes `T::value_type` if `T` is a specialization of `{recursive_wrapper}`. Otherwise, denotes `T`.
+
 [,cpp,subs="+macros,+attributes"]
 ----
+namespace temp_ns {
+
 template<class T>
-constexpr {see-below} pass:quotes[_UNWRAP_RECURSIVE_](T&& o) noexcept; // {exposition-only}
+constexpr auto&& unwrap_recursive(T&& o) noexcept;
+
+} // temp_ns
 ----
 
 [.candidates]
-* [.candidate]#{empty}# *_Effects:_* Denotes `*o`, if cv-unqualified non-reference type for `T` is a specialization of `{recursive_wrapper}`. Otherwise, denotes `o`.
+* [.candidate]#{empty}# *_Returns:_* `*o`, if cv-unqualified non-reference type for `T` is a specialization of `{recursive_wrapper}`. Otherwise, returns `o`.
++
+*_Remarks:_* `unwrap_recursive` is an _algorithm function object_ (link:https://eel.is/c++draft/alg.func.obj[[alg.func.obj\],window=_blank]).
 
 
 [[rvariant.pack]]
@@ -1507,7 +1506,7 @@ struct compact_alternative;
 A variant with a single alternative may introduce unnecessary overhead when used in many places where only the underlying type is actually needed. In such cases, the variant can be _unwrapped_ using `compact_alternative`. This is useful for resolving issues such as https://github.com/boostorg/spirit/issues/610[boostorg/spirit#610].
 
 [WARNING]
-`compact_alternative` does not unwrap `{recursive_wrapper}`. This is intentional, because doing so could lead to instantiating incomplete type on undesired timings. You may apply `{unwrap_recursive_t}` manually.
+`compact_alternative` does not unwrap `{recursive_wrapper}`. This is intentional, because doing so could lead to instantiating incomplete type on undesired timings. You may apply `{unwrap_recursive_type}` manually.
 
 
 [[rvariant.xo]]

--- a/doc/rvariant.html
+++ b/doc/rvariant.html
@@ -904,7 +904,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
 <li><a href="#rvariant.recursive.ctor">Constructors</a></li>
 </ul>
 </li>
-<li><a href="#rvariant.recursive.helper"><code>recursive_wrapper</code> helper classes <span class="slug">[rvariant.recursive.helper]</span></a></li>
+<li><a href="#rvariant.recursive.helper"><code>recursive_wrapper</code> helper utilities <span class="slug">[rvariant.recursive.helper]</span></a></li>
 <li><a href="#rvariant.pack">Pack manipulation and deduping <span class="slug">[rvariant.pack]</span></a></li>
 <li><a href="#rvariant.xo">Exposition-only utilities <span class="slug">[rvariant.xo]</span></a>
 <ul class="sectlevel2">
@@ -956,7 +956,7 @@ expr.visit(temp_ns::overloaded{
 <p>Clang 21-22 (libc++)</p>
 </li>
 <li>
-<p>MSVC (2022)</p>
+<p>MSVC 2022 and 2026</p>
 </li>
 <li>
 <p>C&#43;&#43;23 and C&#43;&#43;26</p>
@@ -1343,9 +1343,8 @@ template&lt;class T, class Allocator&gt;
   /* constexpr */ std::size_t hash_value(recursive_wrapper&lt;T, Allocator&gt; const&amp;);
 
 // <a href="#rvariant.recursive.helper">[rvariant.recursive.helper]</a>, <code>recursive_wrapper</code> helper classes
-template&lt;class T&gt; struct unwrap_recursive;
-template&lt;class T, class Allocator&gt; struct unwrap_recursive&lt;recursive_wrapper&lt;T, Allocator&gt;&gt;;
-template&lt;class T&gt; using unwrap_recursive_t = typename unwrap_recursive&lt;T&gt;::type;
+template&lt;class T&gt; using unwrap_recursive_type = <span class="see-below">see below</span>;
+template&lt;class T&gt; constexpr auto&amp;&amp; unwrap_recursive(T&amp;&amp; o) noexcept;
 
 // <a href="#rvariant.pack">[rvariant.pack]</a>, pack manipulation and deduping
 template&lt;template&lt;class...&gt; class TT, class A, class B&gt;
@@ -1508,7 +1507,7 @@ See also: spec of <a href="https://eel.is/c++draft/variant"><code>std::variant</
 <div class="ulist">
 <ul>
 <li>
-<p>Let <code>VT<sub><em>i</em></sub></code> denote <code><a href="#rvariant.recursive">recursive_wrapper</a>&lt;T<sub><em>i</em></sub>, A&gt;</code> (for any type <code>A</code>) if such a specialization occurs anywhere in <code>Ts...</code>; otherwise, let <code>VT<sub><em>i</em></sub></code> denote <code>T<sub><em>i</em></sub></code>. Let <code>U<sub><em>j</em></sub></code> denote the <em>j</em><sup>th</sup> type of the template parameter pack having the name <code>Us</code> on each flexibility-related functions. <span class="underline">The <em>corresponding alternative</em> for <code>rvariant</code> is the first type for which <code>std::is_same_v&lt;<a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;VT<sub><em>i</em></sub>&gt;, <a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;U<sub><em>j</em></sub>&gt;&gt;</code> is <code>true</code></span>.</p>
+<p>Let <code>VT<sub><em>i</em></sub></code> denote <code><a href="#rvariant.recursive">recursive_wrapper</a>&lt;T<sub><em>i</em></sub>, A&gt;</code> (for any type <code>A</code>) if such a specialization occurs anywhere in <code>Ts...</code>; otherwise, let <code>VT<sub><em>i</em></sub></code> denote <code>T<sub><em>i</em></sub></code>. Let <code>U<sub><em>j</em></sub></code> denote the <em>j</em><sup>th</sup> type of the template parameter pack having the name <code>Us</code> on each flexibility-related functions. <span class="underline">The <em>corresponding alternative</em> for <code>rvariant</code> is the first type for which <code>std::is_same_v&lt;<a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;VT<sub><em>i</em></sub>&gt;, <a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;U<sub><em>j</em></sub>&gt;&gt;</code> is <code>true</code></span>.</p>
 </li>
 </ul>
 </div>
@@ -1557,7 +1556,7 @@ Equivalent to the <code>std::variant</code> counterpart. <sup><a href="https://e
 <li>
 <p><span class="candidate">4)</span> <em>Generic constructor</em>. Equivalent to the <code>std::variant</code> counterpart, <sup><a href="https://eel.is/c++draft/variant.ctor">[spec]</a></sup> except:</p>
 <div class="paragraph">
-<p><strong><em>Postconditions:</em></strong> <code>holds_alternative<span class="underline">&lt;<a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;T<sub><em>j</em></sub>&gt;&gt;</span>(*this)</code> is <code>true</code>.</p>
+<p><strong><em>Postconditions:</em></strong> <code>holds_alternative<span class="underline">&lt;<a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;T<sub><em>j</em></sub>&gt;&gt;</span>(*this)</code> is <code>true</code>.</p>
 </div>
 </li>
 <li>
@@ -1573,7 +1572,7 @@ Equivalent to the <code>std::variant</code> counterpart. <sup><a href="https://e
 <div class="ulist none">
 <ul class="none">
 <li>
-<p>&#8201;&#8212;&#8201;There is exactly one occurrence of <code>T</code> in <span class="underline"><code><a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;Ts&gt;...</code></span> and</p>
+<p>&#8201;&#8212;&#8201;There is exactly one occurrence of <code>T</code> in <span class="underline"><code><a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;Ts&gt;...</code></span> and</p>
 </li>
 <li>
 <p>&#8201;&#8212;&#8201;<code>std::is_constructible_v&lt;<span class="underline">VT</span>, Args...&gt;</code> is <code>true</code>.</p>
@@ -1608,7 +1607,7 @@ Equivalent to the <code>std::variant</code> counterpart. <sup><a href="https://e
 <div class="ulist none">
 <ul class="none">
 <li>
-<p>&#8201;&#8212;&#8201;There is exactly one occurrence of <code>T</code> in <span class="underline"><code><a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;Ts&gt;...</code></span> and</p>
+<p>&#8201;&#8212;&#8201;There is exactly one occurrence of <code>T</code> in <span class="underline"><code><a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;Ts&gt;...</code></span> and</p>
 </li>
 <li>
 <p>&#8201;&#8212;&#8201;<code>std::is_constructible_v&lt;<span class="underline">VT</span>, std::initializer_list&lt;U&gt;&amp;, Args...&gt;</code> is <code>true</code>.</p>
@@ -1653,7 +1652,7 @@ Equivalent to the <code>std::variant</code> counterpart. <sup><a href="https://e
 <p>&#8201;&#8212;&#8201;<span class="underline"><code><a href="#rvariant.flex">rvariant_set::subset_of</a>&lt;rvariant&lt;Us...&gt;, rvariant&gt;</code> is <code>true</code>, and</span></p>
 </li>
 <li>
-<p>&#8201;&#8212;&#8201;<span class="underline"><code>std::disjunction_v&lt;std::is_same&lt;rvariant&lt;Us...&gt;, <a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;Ts&gt;&gt;...&gt;</code> is <code>false</code>, and</span></p>
+<p>&#8201;&#8212;&#8201;<span class="underline"><code>std::disjunction_v&lt;std::is_same&lt;rvariant&lt;Us...&gt;, <a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;Ts&gt;&gt;...&gt;</code> is <code>false</code>, and</span></p>
 </li>
 <li>
 <p>&#8201;&#8212;&#8201;<span class="underline"><code>std::is_constructible_v&lt;VT<sub><em>i</em></sub>, U<sub><em>j</em></sub> const&amp;&gt;</code> is <code>true</code> for all <em>j</em>.</span></p>
@@ -1698,7 +1697,7 @@ Equivalent to the <code>std::variant</code> counterpart. <sup><a href="https://e
 <p>&#8201;&#8212;&#8201;<code><a href="#rvariant.flex">rvariant_set::subset_of</a>&lt;rvariant&lt;Us...&gt;, rvariant&gt;</code> is <code>true</code>, and</p>
 </li>
 <li>
-<p>&#8201;&#8212;&#8201;<code>std::disjunction_v&lt;std::is_same&lt;rvariant&lt;Us...&gt;, <a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;Ts&gt;&gt;...&gt;</code> is <code>false</code>, and</p>
+<p>&#8201;&#8212;&#8201;<code>std::disjunction_v&lt;std::is_same&lt;rvariant&lt;Us...&gt;, <a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;Ts&gt;&gt;...&gt;</code> is <code>false</code>, and</p>
 </li>
 <li>
 <p>&#8201;&#8212;&#8201;<code>std::is_constructible_v&lt;VT<sub><em>i</em></sub>, <span class="underline">U<sub><em>j</em></sub>&amp;&amp;</span>&gt;</code> is <code>true</code> for all <em>j</em>.</p>
@@ -1776,7 +1775,7 @@ Equivalent to the <code>std::variant</code> counterpart. <sup><a href="https://e
 <li>
 <p><span class="candidate">3)</span> <em>Generic assignment operator</em>. Equivalent to the <code>std::variant</code> counterpart, <sup><a href="https://eel.is/c++draft/variant.assign">[spec]</a></sup> except:</p>
 <div class="paragraph">
-<p><strong><em>Postconditions:</em></strong> <code>holds_alternative<span class="underline">&lt;<a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;T<sub><em>j</em></sub>&gt;&gt;</span>(*this)</code> is <code>true</code>, with <code>T<sub><em>j</em></sub></code> selected by the imaginary function overload resolution described above.</p>
+<p><strong><em>Postconditions:</em></strong> <code>holds_alternative<span class="underline">&lt;<a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;T<sub><em>j</em></sub>&gt;&gt;</span>(*this)</code> is <code>true</code>, with <code>T<sub><em>j</em></sub></code> selected by the imaginary function overload resolution described above.</p>
 </div>
 </li>
 <li>
@@ -1798,7 +1797,7 @@ Equivalent to the <code>std::variant</code> counterpart. <sup><a href="https://e
 <p>&#8201;&#8212;&#8201;<span class="underline"><code><a href="#rvariant.flex">rvariant_set::subset_of</a>&lt;rvariant&lt;Us...&gt;, rvariant&gt;</code> is <code>true</code>, and</span></p>
 </li>
 <li>
-<p>&#8201;&#8212;&#8201;<span class="underline"><code>std::disjunction_v&lt;std::is_same&lt;rvariant&lt;Us...&gt;, <a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;Ts&gt;&gt;...&gt;</code> is <code>false</code>, and</span></p>
+<p>&#8201;&#8212;&#8201;<span class="underline"><code>std::disjunction_v&lt;std::is_same&lt;rvariant&lt;Us...&gt;, <a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;Ts&gt;&gt;...&gt;</code> is <code>false</code>, and</span></p>
 </li>
 <li>
 <p>&#8201;&#8212;&#8201;<span class="underline"><code>std::is_constructible_v&lt;VT<sub><em>i</em></sub>, U<sub><em>j</em></sub> const&amp;&gt; &amp;&amp; std::is_assignable_v&lt;VT<sub><em>i</em></sub>&amp;, U<sub><em>j</em></sub> const&amp;&gt;</code> is <code>true</code> for all <em>j</em>.</span></p>
@@ -1824,7 +1823,7 @@ Equivalent to the <code>std::variant</code> counterpart. <sup><a href="https://e
 <p>&#8201;&#8212;&#8201;Otherwise, if <code>rhs</code> holds a value but <code>*this</code> does not, initializes <code>rvariant</code> to hold <span class="underline"><code>VT<sub><em>i</em></sub></code> (with <em>i</em> being the index of the alternative corresponding to that of <code>rhs</code>)</span> and direct-initializes the contained value with <span class="underline"><code><em>GET</em>&lt;<em>j</em>&gt;(rhs)</code>.</span></p>
 </li>
 <li>
-<p>&#8201;&#8212;&#8201;Otherwise, if <span class="underline"><code>std::is_same_v&lt;<a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;T<sub><em>i</em></sub>&gt;, <a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;U<sub><em>j</em></sub>&gt;&gt;</code> is <code>true</code></span>, assigns <span class="underline"><code><em>GET</em>&lt;<em>j</em>&gt;(rhs)</code></span> to the value contained in <code>*this</code>. <span class="underline">(<em>Note:</em> the left hand side is <code>T<sub><em>i</em></sub></code>, <em>not</em> <code>VT<sub><em>i</em></sub></code>. This ensures that the existing storage is reused even for <code>rvariant</code> with duplicate corresponding alternatives; i.e., <code>index()</code> is unchanged.)</span></p>
+<p>&#8201;&#8212;&#8201;Otherwise, if <span class="underline"><code>std::is_same_v&lt;<a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;T<sub><em>i</em></sub>&gt;, <a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;U<sub><em>j</em></sub>&gt;&gt;</code> is <code>true</code></span>, assigns <span class="underline"><code><em>GET</em>&lt;<em>j</em>&gt;(rhs)</code></span> to the value contained in <code>*this</code>. <span class="underline">(<em>Note:</em> the left hand side is <code>T<sub><em>i</em></sub></code>, <em>not</em> <code>VT<sub><em>i</em></sub></code>. This ensures that the existing storage is reused even for <code>rvariant</code> with duplicate corresponding alternatives; i.e., <code>index()</code> is unchanged.)</span></p>
 </li>
 <li>
 <p>&#8201;&#8212;&#8201;Otherwise, if either <code>std::is_nothrow_constructible_v&lt;VT<sub><em>i</em></sub>, U<sub><em>j</em></sub> const&amp;&gt;</code> is <code>true</code> or <code>std::is_nothrow_move_constructible_v&lt;VT<sub><em>i</em></sub>&gt;</code> is <code>false</code>, equivalent to <code>emplace<span class="underline">&lt;VT<sub><em>i</em></sub>&gt;</span>(<em>GET</em>&lt;<em>j</em>&gt;(rhs))</code>.</p>
@@ -1865,7 +1864,7 @@ Equivalent to the <code>std::variant</code> counterpart. <sup><a href="https://e
 <p>&#8201;&#8212;&#8201;<span class="underline"><code><a href="#rvariant.flex">rvariant_set::subset_of</a>&lt;rvariant&lt;Us...&gt;, rvariant&gt;</code> is <code>true</code>, and</span></p>
 </li>
 <li>
-<p>&#8201;&#8212;&#8201;<span class="underline"><code>std::disjunction_v&lt;std::is_same&lt;rvariant&lt;Us...&gt;, <a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;Ts&gt;&gt;...&gt;</code> is <code>false</code>, and</span></p>
+<p>&#8201;&#8212;&#8201;<span class="underline"><code>std::disjunction_v&lt;std::is_same&lt;rvariant&lt;Us...&gt;, <a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;Ts&gt;&gt;...&gt;</code> is <code>false</code>, and</span></p>
 </li>
 <li>
 <p>&#8201;&#8212;&#8201;<span class="underline"><code>std::is_constructible_v&lt;VT<sub><em>i</em></sub>, U<sub><em>j</em></sub>&amp;&amp;&gt; &amp;&amp; std::is_assignable_v&lt;VT<sub><em>i</em></sub>&amp;, U<sub><em>j</em></sub>&amp;&amp;&gt;</code> is <code>true</code> for all <em>j</em>.</span></p>
@@ -1891,7 +1890,7 @@ Equivalent to the <code>std::variant</code> counterpart. <sup><a href="https://e
 <p>&#8201;&#8212;&#8201;Otherwise, if <code>rhs</code> holds a value but <code>*this</code> does not, initializes <code>rvariant</code> to hold <span class="underline"><code>VT<sub><em>i</em></sub></code> (with <em>i</em> being the index of the alternative corresponding to that of <code>rhs</code>)</span> and direct-initializes the contained value with <span class="underline"><code><em>GET</em>&lt;<em>j</em>&gt;(std::move(rhs))</code>.</span></p>
 </li>
 <li>
-<p>&#8201;&#8212;&#8201;Otherwise, if <span class="underline"><code>std::is_same_v&lt;<a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;T<sub><em>i</em></sub>&gt;, <a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;U<sub><em>j</em></sub>&gt;&gt;</code> is <code>true</code></span>, assigns <span class="underline"><code><em>GET</em>&lt;<em>j</em>&gt;(std::move(rhs))</code></span> to the value contained in <code>*this</code>. <span class="underline">(<em>Note:</em> the left hand side is <code>T<sub><em>i</em></sub></code>, <em>not</em> <code>VT<sub><em>i</em></sub></code>. This ensures that the existing storage is reused even for <code>rvariant</code> with duplicate corresponding alternatives; i.e., <code>index()</code> is unchanged.)</span></p>
+<p>&#8201;&#8212;&#8201;Otherwise, if <span class="underline"><code>std::is_same_v&lt;<a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;T<sub><em>i</em></sub>&gt;, <a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;U<sub><em>j</em></sub>&gt;&gt;</code> is <code>true</code></span>, assigns <span class="underline"><code><em>GET</em>&lt;<em>j</em>&gt;(std::move(rhs))</code></span> to the value contained in <code>*this</code>. <span class="underline">(<em>Note:</em> the left hand side is <code>T<sub><em>i</em></sub></code>, <em>not</em> <code>VT<sub><em>i</em></sub></code>. This ensures that the existing storage is reused even for <code>rvariant</code> with duplicate corresponding alternatives; i.e., <code>index()</code> is unchanged.)</span></p>
 </li>
 <li>
 <p>&#8201;&#8212;&#8201;Otherwise, equivalent to <code>emplace<span class="underline">&lt;VT<sub><em>i</em></sub>&gt;</span>(<em>GET</em>&lt;<em>j</em>&gt;(std::move(rhs)))</code>.</p>
@@ -1937,12 +1936,12 @@ constexpr variant_alternative_t&lt;I, rvariant&lt;Ts...&gt;&gt;&amp;
 <p><strong><em>Mandates:</em></strong> <span class="underline"><code>T</code> is not a specialization of <code><a href="#rvariant.recursive">recursive_wrapper</a></code>.</span></p>
 </div>
 <div class="paragraph">
-<p><strong><em>Constraints:</em></strong> <code>std::is_constructible_v&lt;<span class="underline">VT</span>, Args...&gt;</code> is <code>true</code>, and <code>T</code> occurs exactly once in <span class="underline"><code><a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;Ts&gt;</code></span>.</p>
+<p><strong><em>Constraints:</em></strong> <code>std::is_constructible_v&lt;<span class="underline">VT</span>, Args...&gt;</code> is <code>true</code>, and <code>T</code> occurs exactly once in <span class="underline"><code><a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;Ts&gt;</code></span>.</p>
 </div>
 <div class="paragraph">
 <p><strong><em>Effects:</em></strong> Equivalent to:<br>
 &nbsp;&nbsp;<code>return emplace&lt;<em>I</em>&gt;(std::forward&lt;Args&gt;(args)...);</code><br>
-where <code><em>I</em></code> is the zero-based index of <code>T</code> in <span class="underline"><code><a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;Ts&gt;</code></span>.</p>
+where <code><em>I</em></code> is the zero-based index of <code>T</code> in <span class="underline"><code><a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;Ts&gt;</code></span>.</p>
 </div>
 </li>
 <li>
@@ -1951,18 +1950,18 @@ where <code><em>I</em></code> is the zero-based index of <code>T</code> in <span
 <p><strong><em>Mandates:</em></strong> <span class="underline"><code>T</code> is not a specialization of <code><a href="#rvariant.recursive">recursive_wrapper</a></code>.</span></p>
 </div>
 <div class="paragraph">
-<p><strong><em>Constraints:</em></strong> <code>std::is_constructible_v&lt;<span class="underline">VT</span>, std::initializer_list&lt;U&gt;&amp;, Args...&gt;</code> is <code>true</code>, and <code>T</code> occurs exactly once in <span class="underline"><code><a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;Ts&gt;</code></span>.</p>
+<p><strong><em>Constraints:</em></strong> <code>std::is_constructible_v&lt;<span class="underline">VT</span>, std::initializer_list&lt;U&gt;&amp;, Args...&gt;</code> is <code>true</code>, and <code>T</code> occurs exactly once in <span class="underline"><code><a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;Ts&gt;</code></span>.</p>
 </div>
 <div class="paragraph">
 <p><strong><em>Effects:</em></strong> Equivalent to:<br>
 &nbsp;&nbsp;<code>return emplace&lt;<em>I</em>&gt;(il, std::forward&lt;Args&gt;(args)...);</code><br>
-where <code><em>I</em></code> is the zero-based index of <code>T</code> in <span class="underline"><code><a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;Ts&gt;</code></span>.</p>
+where <code><em>I</em></code> is the zero-based index of <code>T</code> in <span class="underline"><code><a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;Ts&gt;</code></span>.</p>
 </div>
 </li>
 <li>
 <p><span class="candidate">3)</span> Equivalent to the <code>std::variant</code> counterpart, <sup><a href="https://eel.is/c++draft/variant.mod">[spec]</a></sup> except:</p>
 <div class="paragraph">
-<p><strong><em>Returns:</em></strong> <span class="underline">Let <code>o</code> denote</span> a reference to the new contained value. <span class="underline">Returns <code><em><a href="#rvariant.recursive.helper">UNWRAP_RECURSIVE</a></em>(o)</code>.</span></p>
+<p><strong><em>Returns:</em></strong> <span class="underline">Let <code>o</code> denote</span> a reference to the new contained value. <span class="underline">Returns <code><a href="#rvariant.recursive.helper">unwrap_recursive</a>(o)</code>.</span></p>
 </div>
 <div class="paragraph">
 <p><strong><em>Remarks:</em></strong> <span class="underline">If <code>T<sub><em>I</em></sub></code> is a specialization of <code><a href="#rvariant.recursive">recursive_wrapper</a></code>, this function is permitted to construct an intermediate variable <code>tmp</code> as if by passing <code>std::forward&lt;Args&gt;(args)...</code> to <code>T<sub><em>I</em></sub></code>'s constructor. Then <code>rvariant</code> direct-non-list-initializes the contained value of <code>T<sub><em>I</em></sub></code> with the argument <code>std::move(tmp)</code>. (<em>Note:</em> This allows optimization where <code>rvariant</code> can be assumed to become never valueless on certain cases.)</span></p>
@@ -1971,7 +1970,7 @@ where <code><em>I</em></code> is the zero-based index of <code>T</code> in <span
 <li>
 <p><span class="candidate">4)</span> Equivalent to the <code>std::variant</code> counterpart, <sup><a href="https://eel.is/c++draft/variant.mod">[spec]</a></sup> except:</p>
 <div class="paragraph">
-<p><strong><em>Returns:</em></strong> <span class="underline">Let <code>o</code> denote</span> a reference to the new contained value. <span class="underline">Returns <code><em><a href="#rvariant.recursive.helper">UNWRAP_RECURSIVE</a></em>(o)</code>.</span></p>
+<p><strong><em>Returns:</em></strong> <span class="underline">Let <code>o</code> denote</span> a reference to the new contained value. <span class="underline">Returns <code><a href="#rvariant.recursive.helper">unwrap_recursive</a>(o)</code>.</span></p>
 </div>
 <div class="paragraph">
 <p><strong><em>Remarks:</em></strong> <span class="underline">If <code>T<sub><em>I</em></sub></code> is a specialization of <code><a href="#rvariant.recursive">recursive_wrapper</a></code>, this function is permitted to construct an intermediate variable <code>tmp</code> as if by passing <code>il, std::forward&lt;Args&gt;(args)...</code> to <code>T<sub><em>I</em></sub></code>'s constructor. Then <code>rvariant</code> direct-non-list-initializes the contained value of <code>T<sub><em>I</em></sub></code> with the argument <code>std::move(tmp)</code>. (<em>Note:</em> This allows optimization where <code>rvariant</code> can be assumed to become never valueless on certain cases.)</span></p>
@@ -2122,7 +2121,7 @@ struct variant_alternative&lt;I, rvariant&lt;Ts...&gt;&gt;;<span class="candidat
 Equivalent to the <code>std::variant</code> counterpart. <sup><a href="https://eel.is/c++draft/variant#helper-3">[spec]</a></sup></p>
 </li>
 <li>
-<p><span class="candidate">2)</span> The member typedef <code>type</code> denotes <span class="underline"><code><a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;T<sub><em>I</em></sub>&gt;</code></span>.</p>
+<p><span class="candidate">2)</span> The member typedef <code>type</code> denotes <span class="underline"><code><a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;T<sub><em>I</em></sub>&gt;</code></span>.</p>
 <div class="paragraph">
 <p><strong><em>Mandates:</em></strong> <code>I &lt; sizeof...(Ts)</code>.</p>
 </div>
@@ -2169,7 +2168,7 @@ concept equivalent_to = subset_of&lt;W, V&gt; &amp;&amp; subset_of&lt;V, W&gt;;
 <p>&#8201;&#8212;&#8201;<code>T</code> is the same type as <code>U</code> or,</p>
 </li>
 <li>
-<p>&#8201;&#8212;&#8201;<code><a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;T&gt;</code> is the same type as <code>U</code>.</p>
+<p>&#8201;&#8212;&#8201;<code><a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;T&gt;</code> is the same type as <code>U</code>.</p>
 </li>
 </ul>
 </div>
@@ -2194,9 +2193,9 @@ constexpr bool holds_alternative(rvariant&lt;Ts...&gt; const&amp; v) noexcept;
 <div class="ulist candidates">
 <ul>
 <li>
-<p><span class="candidate"></span> <strong><em>Mandates:</em></strong> The type <code>T</code> occurs exactly once in <span class="underline"><code><a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;Ts&gt;</code></span>.</p>
+<p><span class="candidate"></span> <strong><em>Mandates:</em></strong> The type <code>T</code> occurs exactly once in <span class="underline"><code><a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;Ts&gt;</code></span>.</p>
 <div class="paragraph">
-<p><strong><em>Returns:</em></strong> <code>true</code> if <code>v.index()</code> is equal to the zero-based index of <code>T</code> in <span class="underline"><code><a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;Ts&gt;</code></span>.</p>
+<p><strong><em>Returns:</em></strong> <code>true</code> if <code>v.index()</code> is equal to the zero-based index of <code>T</code> in <span class="underline"><code><a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;Ts&gt;</code></span>.</p>
 </div>
 <div class="paragraph">
 <p><strong><em>Remarks:</em></strong> <span class="underline">This function is defined as deleted if <code>T</code> is a specialization of <code><a href="#rvariant.recursive">recursive_wrapper</a></code>.</span></p>
@@ -2227,7 +2226,7 @@ constexpr <span class="see-below">see below</span> const&amp;&amp; <em>GET</em>(
 <p><strong><em>Preconditions:</em></strong> <code>v.index()</code> is <code>I</code>.</p>
 </div>
 <div class="paragraph">
-<p><strong><em>Returns:</em></strong> <span class="underline"><code>o</code>, where <code>o</code> denotes a reference to the object stored in <code>v</code>, if the type of the expression&#8217;s receiver is a specialization of <code><a href="#rvariant.recursive">recursive_wrapper</a></code>; otherwise, returns <code><em><a href="#rvariant.recursive.helper">UNWRAP_RECURSIVE</a></em>(o)</code></span>.</p>
+<p><strong><em>Returns:</em></strong> <span class="underline"><code>o</code>, where <code>o</code> denotes a reference to the object stored in <code>v</code>, if the type of the expression&#8217;s receiver is a specialization of <code><a href="#rvariant.recursive">recursive_wrapper</a></code>; otherwise, returns <code><a href="#rvariant.recursive.helper">unwrap_recursive</a>(o)</code></span>.</p>
 </div>
 </li>
 </ul>
@@ -2260,7 +2259,7 @@ constexpr variant_alternative_t&lt;I, rvariant&lt;Ts...&gt;&gt; const&amp;&amp;
 <li>
 <p><span class="candidate"></span> <strong><em>Mandates:</em></strong> <code>I &lt; sizeof...(Ts)</code>.</p>
 <div class="paragraph">
-<p><strong><em>Effects:</em></strong> If <code>v.index()</code> is <code>I</code>, returns <span class="underline"><code><em><a href="#rvariant.recursive.helper">UNWRAP_RECURSIVE</a></em>(o)</code>, where <code>o</code> denotes a reference to the object stored in the <code>rvariant</code></span>. Otherwise, throws an exception of type <a href="https://eel.is/c++draft/variant.bad.access"><code>std::bad_variant_access</code></a>.</p>
+<p><strong><em>Effects:</em></strong> If <code>v.index()</code> is <code>I</code>, returns <span class="underline"><code><a href="#rvariant.recursive.helper">unwrap_recursive</a>(o)</code>, where <code>o</code> denotes a reference to the object stored in the <code>rvariant</code></span>. Otherwise, throws an exception of type <a href="https://eel.is/c++draft/variant.bad.access"><code>std::bad_variant_access</code></a>.</p>
 </div>
 </li>
 </ul>
@@ -2280,9 +2279,9 @@ template&lt;class T, class... Ts&gt; constexpr T const&amp;&amp; get(rvariant&lt
 <div class="ulist candidates">
 <ul>
 <li>
-<p><span class="candidate"></span> <strong><em>Mandates:</em></strong> The type <code>T</code> occurs exactly once in <span class="underline"><code><a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;Ts&gt;</code></span>.</p>
+<p><span class="candidate"></span> <strong><em>Mandates:</em></strong> The type <code>T</code> occurs exactly once in <span class="underline"><code><a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;Ts&gt;</code></span>.</p>
 <div class="paragraph">
-<p><strong><em>Effects:</em></strong> <span class="underline">Let <code>VT</code> denote the type of the alternative held by <code>v</code>. If <code><a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;VT&gt;</code> is the same type as <code>T</code></span>, returns <span class="underline"><code><em><a href="#rvariant.recursive.helper">UNWRAP_RECURSIVE</a></em>(o)</code>, where <code>o</code> denotes a reference to the object stored in the <code>rvariant</code></span>. Otherwise, throws an exception of type <a href="https://eel.is/c++draft/variant.bad.access"><code>std::bad_variant_access</code></a>.</p>
+<p><strong><em>Effects:</em></strong> <span class="underline">Let <code>VT</code> denote the type of the alternative held by <code>v</code>. If <code><a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;VT&gt;</code> is the same type as <code>T</code></span>, returns <span class="underline"><code><a href="#rvariant.recursive.helper">unwrap_recursive</a>(o)</code>, where <code>o</code> denotes a reference to the object stored in the <code>rvariant</code></span>. Otherwise, throws an exception of type <a href="https://eel.is/c++draft/variant.bad.access"><code>std::bad_variant_access</code></a>.</p>
 </div>
 <div class="paragraph">
 <p><strong><em>Remarks:</em></strong> <span class="underline">This function is defined as deleted if <code>T</code> is a specialization of <code><a href="#rvariant.recursive">recursive_wrapper</a></code>.</span></p>
@@ -2310,7 +2309,7 @@ constexpr std::add_pointer_t&lt;variant_alternative_t&lt;I, rvariant&lt;Ts...&gt
 <li>
 <p><span class="candidate">1-2)</span> <strong><em>Mandates:</em></strong> <code>I &lt; sizeof...(Ts)</code>.</p>
 <div class="paragraph">
-<p><strong><em>Returns:</em></strong> A pointer to the value <span class="underline">denoted by <code><em><a href="#rvariant.recursive.helper">UNWRAP_RECURSIVE</a></em>(o)</code>, where <code>o</code> denotes a reference to the object stored in the <code>rvariant</code></span>, if <code>v != nullptr</code> and <code>v-&gt;index() == I</code>. Otherwise, returns <code>nullptr</code>.</p>
+<p><strong><em>Returns:</em></strong> A pointer to the value <span class="underline">denoted by <code><a href="#rvariant.recursive.helper">unwrap_recursive</a>(o)</code>, where <code>o</code> denotes a reference to the object stored in the <code>rvariant</code></span>, if <code>v != nullptr</code> and <code>v-&gt;index() == I</code>. Otherwise, returns <code>nullptr</code>.</p>
 </div>
 </li>
 </ul>
@@ -2333,9 +2332,9 @@ constexpr std::add_pointer_t&lt;T const&gt;
 <div class="ulist candidates">
 <ul>
 <li>
-<p><span class="candidate">1-2)</span> <strong><em>Mandates:</em></strong> The type <code>T</code> occurs exactly once in <span class="underline"><code><a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;Ts&gt;</code></span>.</p>
+<p><span class="candidate">1-2)</span> <strong><em>Mandates:</em></strong> The type <code>T</code> occurs exactly once in <span class="underline"><code><a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;Ts&gt;</code></span>.</p>
 <div class="paragraph">
-<p><strong><em>Effects:</em></strong> Equivalent to: <code>return get_if&lt;<em>i</em>&gt;(v);</code> with <em>i</em> being the zero-based index of <code>T</code> in <span class="underline"><code><a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;Ts&gt;</code></span>.</p>
+<p><strong><em>Effects:</em></strong> Equivalent to: <code>return get_if&lt;<em>i</em>&gt;(v);</code> with <em>i</em> being the zero-based index of <code>T</code> in <span class="underline"><code><a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;Ts&gt;</code></span>.</p>
 </div>
 <div class="paragraph">
 <p><strong><em>Remarks:</em></strong> <span class="underline">This function is defined as deleted if <code>T</code> is a specialization of <code><a href="#rvariant.recursive">recursive_wrapper</a></code>.</span></p>
@@ -2376,7 +2375,7 @@ constexpr R visit(this Self&amp;&amp; self, Visitor&amp;&amp; vis);<span class="
 <div class="ulist none">
 <ul class="none">
 <li>
-<p>&#8201;&#8212;&#8201;<code><em>GET</em>&lt;<em>m</em>&gt;(std::forward&lt;V&gt;(vars))</code> is replaced with <code><em><a href="#rvariant.recursive.helper">UNWRAP_RECURSIVE</a></em>(<em>GET</em>&lt;<em>m</em>&gt;(std::forward&lt;V&gt;(vars)))</code>.</p>
+<p>&#8201;&#8212;&#8201;<code><em>GET</em>&lt;<em>m</em>&gt;(std::forward&lt;V&gt;(vars))</code> is replaced with <code><a href="#rvariant.recursive.helper">unwrap_recursive</a>(<em>GET</em>&lt;<em>m</em>&gt;(std::forward&lt;V&gt;(vars)))</code>.</p>
 </li>
 </ul>
 </div>
@@ -2489,7 +2488,7 @@ std::ostream&amp; operator&lt;&lt;(std::ostream&amp; os, rvariant&lt;Ts...&gt; c
 </div>
 </li>
 <li>
-<p><span class="candidate">2)</span> <strong><em>Constraints:</em></strong> <code><em>ADL-ostreamable</em>&lt;<a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;T<sub><em>i</em></sub>&gt;&gt;</code> is <code>true</code> for all <em>i</em>.</p>
+<p><span class="candidate">2)</span> <strong><em>Constraints:</em></strong> <code><em>ADL-ostreamable</em>&lt;<a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;T<sub><em>i</em></sub>&gt;&gt;</code> is <code>true</code> for all <em>i</em>.</p>
 <div class="paragraph">
 <p><strong><em>Effects:</em></strong> Behaves as a formatted output function (<a href="https://eel.is/c++draft/ostream.formatted.reqmts">[ostream.formatted.reqmts]</a>) of <code>os</code>, except that:</p>
 </div>
@@ -2498,7 +2497,7 @@ std::ostream&amp; operator&lt;&lt;(std::ostream&amp; os, rvariant&lt;Ts...&gt; c
 <div class="ulist none">
 <ul class="none">
 <li>
-<p>&#8201;&#8212;&#8201;the output is done as if by calling <code>os &lt;&lt; <em><a href="#rvariant.recursive.helper">UNWRAP_RECURSIVE</a></em>(<em>GET</em>&lt;<em>i</em>&gt;(v))</code> (with <em>i</em> being <code>v.index()</code>), and</p>
+<p>&#8201;&#8212;&#8201;the output is done as if by calling <code>os &lt;&lt; <a href="#rvariant.recursive.helper">unwrap_recursive</a>(<em>GET</em>&lt;<em>i</em>&gt;(v))</code> (with <em>i</em> being <code>v.index()</code>), and</p>
 </li>
 <li>
 <p>&#8201;&#8212;&#8201;any exception of type <code>std::bad_variant_access</code>, whether thrown directly (i.e., due to <code>v</code> being valueless) or indirectly (i.e., by a nested call to an alternative&#8217;s output function), is propagated without regard to the value of <code>os.exceptions()</code> and without turning on <code>std::ios_base::badbit</code> in the error state of <code>os</code>.</p>
@@ -2525,7 +2524,7 @@ std::ostream&amp; operator&lt;&lt;(std::ostream&amp; os, rvariant&lt;Ts...&gt; c
 <p>Let <code>v</code> denote an object of <code>rvariant</code>, and let <code>proxy</code> denote an object of <code><em>variant_format_proxy</em></code>.</p>
 </li>
 <li>
-<p>The specialization <code>std::formatter&lt;::temp_ns::rvariant&lt;Ts...&gt;, charT&gt;</code> (for arbitrary <code>charT</code>) is enabled if and only if <code>std::formattable&lt;<a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;Ts<sub><em>i</em></sub>&gt;, charT&gt;</code> is <code>true</code> for all <em>i</em>, with the following characteristics:</p>
+<p>The specialization <code>std::formatter&lt;::temp_ns::rvariant&lt;Ts...&gt;, charT&gt;</code> (for arbitrary <code>charT</code>) is enabled if and only if <code>std::formattable&lt;<a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;Ts<sub><em>i</em></sub>&gt;, charT&gt;</code> is <code>true</code> for all <em>i</em>, with the following characteristics:</p>
 <div class="ulist none">
 <ul class="none">
 <li>
@@ -2535,7 +2534,7 @@ std::ostream&amp; operator&lt;&lt;(std::ostream&amp; os, rvariant&lt;Ts...&gt; c
 <p>&#8201;&#8212;&#8201;if <code>v.valueless_by_exception()</code> is <code>true</code>, <code>std::bad_variant_access</code> is thrown, and</p>
 </li>
 <li>
-<p>&#8201;&#8212;&#8201;the output is done as if by calling <code>std::format_to(fmt_ctx.out(), <em>paren</em>, <em><a href="#rvariant.recursive.helper">UNWRAP_RECURSIVE</a></em>(<em>GET</em>&lt;v.index()&gt;(v)))</code>, with <code><em>paren</em></code> being a string literal <code>"{}"</code> interpreted on the target character type.</p>
+<p>&#8201;&#8212;&#8201;the output is done as if by calling <code>std::format_to(fmt_ctx.out(), <em>paren</em>, <a href="#rvariant.recursive.helper">unwrap_recursive</a>(<em>GET</em>&lt;v.index()&gt;(v)))</code>, with <code><em>paren</em></code> being a string literal <code>"{}"</code> interpreted on the target character type.</p>
 </li>
 <li>
 <p><em>Example:</em></p>
@@ -2559,7 +2558,7 @@ std::ostream&amp; operator&lt;&lt;(std::ostream&amp; os, rvariant&lt;Ts...&gt; c
 <p>&#8201;&#8212;&#8201;<code>std::remove_cvref_t&lt;Variant&gt;</code> is a specialization of <code>rvariant</code>, and</p>
 </li>
 <li>
-<p>&#8201;&#8212;&#8201;<code>std::formattable&lt;<a href="#rvariant.recursive.helper">unwrap_recursive_t</a>&lt;Ts<sub><em>i</em></sub>&gt;, charT&gt;</code> is <code>true</code> for all <em>i</em>, with <code>Ts</code> being the template parameter pack of cv-unqualified non-reference type for <code>Variant</code>.</p>
+<p>&#8201;&#8212;&#8201;<code>std::formattable&lt;<a href="#rvariant.recursive.helper">unwrap_recursive_type</a>&lt;Ts<sub><em>i</em></sub>&gt;, charT&gt;</code> is <code>true</code> for all <em>i</em>, with <code>Ts</code> being the template parameter pack of cv-unqualified non-reference type for <code>Variant</code>.</p>
 </li>
 </ul>
 </div>
@@ -2575,7 +2574,7 @@ std::ostream&amp; operator&lt;&lt;(std::ostream&amp; os, rvariant&lt;Ts...&gt; c
 <p>&#8201;&#8212;&#8201;if <code>v.valueless_by_exception()</code> is <code>true</code>, <code>std::bad_variant_access</code> is thrown, and</p>
 </li>
 <li>
-<p>&#8201;&#8212;&#8201;the output is done as if by calling <code>std::format_to(fmt_ctx.out(), proxy.v_fmt(std::in_place_type&lt;Ts...[proxy.v.index()]&gt;), <em><a href="#rvariant.recursive.helper">UNWRAP_RECURSIVE</a></em>(<em>GET</em>&lt;proxy.v.index()&gt;(proxy.v)))</code>, with <code>Ts</code> being the template parameter pack of the cv-unqualified non-reference type of <code>proxy.v</code>.</p>
+<p>&#8201;&#8212;&#8201;the output is done as if by calling <code>std::format_to(fmt_ctx.out(), proxy.v_fmt(std::in_place_type&lt;Ts...[proxy.v.index()]&gt;), <a href="#rvariant.recursive.helper">unwrap_recursive</a>(<em>GET</em>&lt;proxy.v.index()&gt;(proxy.v)))</code>, with <code>Ts</code> being the template parameter pack of the cv-unqualified non-reference type of <code>proxy.v</code>.</p>
 </li>
 <li>
 <p><em>Example:</em></p>
@@ -2834,37 +2833,42 @@ constexpr <span class="underline">/* not explicit */</span> recursive_wrapper(U&
 </div>
 </div>
 <div class="sect1">
-<h2 id="rvariant.recursive.helper"><a class="anchor" href="#rvariant.recursive.helper"></a><code>recursive_wrapper</code> helper classes <span class="slug"><a href="#rvariant.recursive.helper">[rvariant.recursive.helper]</a></span></h2>
+<h2 id="rvariant.recursive.helper"><a class="anchor" href="#rvariant.recursive.helper"></a><code>recursive_wrapper</code> helper utilities <span class="slug"><a href="#rvariant.recursive.helper">[rvariant.recursive.helper]</a></span></h2>
 <div class="sectionbody">
 <div class="listingblock">
 <div class="content">
 <pre class="highlight"><code class="language-cpp" data-lang="cpp">namespace temp_ns {
 
 template&lt;class T&gt;
-struct unwrap_recursive
-{
-  using type = T;
-};
-
-template&lt;class T, class Allocator&gt;
-struct unwrap_recursive&lt;recursive_wrapper&lt;T, Allocator&gt;&gt;
-{
-  using type = T;
-};
+using unwrap_recursive_type = <span class="see-below">see below</span>;
 
 } // temp_ns</code></pre>
-</div>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-cpp" data-lang="cpp">template&lt;class T&gt;
-constexpr <span class="see-below">see below</span> <em>UNWRAP_RECURSIVE</em>(T&amp;&amp; o) noexcept; // <span class="exposition-only">exposition only</span></code></pre>
 </div>
 </div>
 <div class="ulist candidates">
 <ul>
 <li>
-<p><span class="candidate"></span> <strong><em>Effects:</em></strong> Denotes <code>*o</code>, if cv-unqualified non-reference type for <code>T</code> is a specialization of <code><a href="#rvariant.recursive">recursive_wrapper</a></code>. Otherwise, denotes <code>o</code>.</p>
+<p><span class="candidate"></span> Denotes <code>T::value_type</code> if <code>T</code> is a specialization of <code><a href="#rvariant.recursive">recursive_wrapper</a></code>. Otherwise, denotes <code>T</code>.</p>
+</li>
+</ul>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-cpp" data-lang="cpp">namespace temp_ns {
+
+template&lt;class T&gt;
+constexpr auto&amp;&amp; unwrap_recursive(T&amp;&amp; o) noexcept;
+
+} // temp_ns</code></pre>
+</div>
+</div>
+<div class="ulist candidates">
+<ul>
+<li>
+<p><span class="candidate"></span> <strong><em>Returns:</em></strong> <code>*o</code>, if cv-unqualified non-reference type for <code>T</code> is a specialization of <code><a href="#rvariant.recursive">recursive_wrapper</a></code>. Otherwise, returns <code>o</code>.</p>
+<div class="paragraph">
+<p><strong><em>Remarks:</em></strong> <code>unwrap_recursive</code> is an <em>algorithm function object</em> (<a href="https://eel.is/c++draft/alg.func.obj" target="_blank" rel="noopener">[alg.func.obj]</a>).</p>
+</div>
 </li>
 </ul>
 </div>
@@ -2913,7 +2917,7 @@ A variant with a single alternative may introduce unnecessary overhead when used
 <i class="fa icon-warning" title="Warning"></i>
 </td>
 <td class="content">
-<code>compact_alternative</code> does not unwrap <code><a href="#rvariant.recursive">recursive_wrapper</a></code>. This is intentional, because doing so could lead to instantiating incomplete type on undesired timings. You may apply <code><a href="#rvariant.recursive.helper">unwrap_recursive_t</a></code> manually.
+<code>compact_alternative</code> does not unwrap <code><a href="#rvariant.recursive">recursive_wrapper</a></code>. This is intentional, because doing so could lead to instantiating incomplete type on undesired timings. You may apply <code><a href="#rvariant.recursive.helper">unwrap_recursive_type</a></code> manually.
 </td>
 </tr>
 </table>

--- a/include/iris/rvariant/detail/visit.hpp
+++ b/include/iris/rvariant/detail/visit.hpp
@@ -1,4 +1,4 @@
-﻿#ifndef IRIS_RVARIANT_DETAIL_VISIT_HPP
+#ifndef IRIS_RVARIANT_DETAIL_VISIT_HPP
 #define IRIS_RVARIANT_DETAIL_VISIT_HPP
 
 // SPDX-License-Identifier: MIT
@@ -306,16 +306,16 @@ struct visit_check_impl<T0R, Visitor, type_list<Args...>>
 
 template<class T0R, class Visitor, class... Args, class... Ts, class... Rest>
 struct visit_check_impl<T0R, Visitor, type_list<Args...>, rvariant<Ts...>&, Rest...>
-    : std::conjunction<visit_check_impl<T0R, Visitor, type_list<Args..., unwrap_recursive_t<Ts>&>, Rest...>...> {};
+    : std::conjunction<visit_check_impl<T0R, Visitor, type_list<Args..., unwrap_recursive_type<Ts>&>, Rest...>...> {};
 template<class T0R, class Visitor, class... Args, class... Ts, class... Rest>
 struct visit_check_impl<T0R, Visitor, type_list<Args...>, rvariant<Ts...> const&, Rest...>
-    : std::conjunction<visit_check_impl<T0R, Visitor, type_list<Args..., unwrap_recursive_t<Ts> const&>, Rest...>...> {};
+    : std::conjunction<visit_check_impl<T0R, Visitor, type_list<Args..., unwrap_recursive_type<Ts> const&>, Rest...>...> {};
 template<class T0R, class Visitor, class... Args, class... Ts, class... Rest>
 struct visit_check_impl<T0R, Visitor, type_list<Args...>, rvariant<Ts...>&&, Rest...>
-    : std::conjunction<visit_check_impl<T0R, Visitor, type_list<Args..., unwrap_recursive_t<Ts>>, Rest...>...> {};
+    : std::conjunction<visit_check_impl<T0R, Visitor, type_list<Args..., unwrap_recursive_type<Ts>>, Rest...>...> {};
 template<class T0R, class Visitor, class... Args, class... Ts, class... Rest>
 struct visit_check_impl<T0R, Visitor, type_list<Args...>, rvariant<Ts...> const&&, Rest...>
-    : std::conjunction<visit_check_impl<T0R, Visitor, type_list<Args..., unwrap_recursive_t<Ts> const>, Rest...>...> {};
+    : std::conjunction<visit_check_impl<T0R, Visitor, type_list<Args..., unwrap_recursive_type<Ts> const>, Rest...>...> {};
 
 template<class T0R, class Visitor, class... Variants>
 using visit_check = visit_check_impl<T0R, Visitor, type_list<>, Variants...>;
@@ -357,16 +357,16 @@ struct visit_R_check_impl<R, Visitor, type_list<Args...>>
 
 template<class R, class Visitor, class... Args, class... Ts, class... Rest>
 struct visit_R_check_impl<R, Visitor, type_list<Args...>, rvariant<Ts...>&, Rest...>
-    : std::conjunction<visit_R_check_impl<R, Visitor, type_list<Args..., unwrap_recursive_t<Ts>&>, Rest...>...> {};
+    : std::conjunction<visit_R_check_impl<R, Visitor, type_list<Args..., unwrap_recursive_type<Ts>&>, Rest...>...> {};
 template<class R, class Visitor, class... Args, class... Ts, class... Rest>
 struct visit_R_check_impl<R, Visitor, type_list<Args...>, rvariant<Ts...> const&, Rest...>
-    : std::conjunction<visit_R_check_impl<R, Visitor, type_list<Args..., unwrap_recursive_t<Ts> const&>, Rest...>...> {};
+    : std::conjunction<visit_R_check_impl<R, Visitor, type_list<Args..., unwrap_recursive_type<Ts> const&>, Rest...>...> {};
 template<class R, class Visitor, class... Args, class... Ts, class... Rest>
 struct visit_R_check_impl<R, Visitor, type_list<Args...>, rvariant<Ts...>&&, Rest...>
-    : std::conjunction<visit_R_check_impl<R, Visitor, type_list<Args..., unwrap_recursive_t<Ts>>, Rest...>...> {};
+    : std::conjunction<visit_R_check_impl<R, Visitor, type_list<Args..., unwrap_recursive_type<Ts>>, Rest...>...> {};
 template<class R, class Visitor, class... Args, class... Ts, class... Rest>
 struct visit_R_check_impl<R, Visitor, type_list<Args...>, rvariant<Ts...> const&&, Rest...>
-    : std::conjunction<visit_R_check_impl<R, Visitor, type_list<Args..., unwrap_recursive_t<Ts> const>, Rest...>...> {};
+    : std::conjunction<visit_R_check_impl<R, Visitor, type_list<Args..., unwrap_recursive_type<Ts> const>, Rest...>...> {};
 
 template<class R, class Visitor, class... Variants>
 using visit_R_check = visit_R_check_impl<R, Visitor, type_list<>, Variants...>;
@@ -387,7 +387,7 @@ private:
         using type = std::is_nothrow_invocable_r<
             R,
             Visitor,
-            unwrap_recursive_t<
+            unwrap_recursive_type<
                 detail::raw_get_t<detail::valueless_unbias<Storage_>(Is), Storage_>
             >...
         >;

--- a/include/iris/rvariant/rvariant.hpp
+++ b/include/iris/rvariant/rvariant.hpp
@@ -420,7 +420,7 @@ IRIS_RVARIANT_ALWAYS_THROWING_UNREACHABLE_BEGIN
                 }
             });
         }
-        return detail::unwrap_recursive(detail::raw_get<I>(storage_));
+        return unwrap_recursive(detail::raw_get<I>(storage_));
     }
 IRIS_RVARIANT_ALWAYS_THROWING_UNREACHABLE_END
 
@@ -493,7 +493,7 @@ class rvariant : private detail::rvariant_base_t<Ts...>
     static_assert((req::Cpp17Destructible<Ts> && ...), "All types shall meet the Cpp17Destructible requirements ([variant.variant.general]).");
     static_assert(sizeof...(Ts) > 0, "A variant with no template arguments shall not be instantiated ([variant.variant.general]).");
 
-    using unwrapped_types = type_list<unwrap_recursive_t<Ts>...>;
+    using unwrapped_types = type_list<unwrap_recursive_type<Ts>...>;
 
     using base_type = detail::rvariant_base_t<Ts...>;
     friend struct detail::rvariant_base<Ts...>;
@@ -586,18 +586,18 @@ IRIS_RVARIANT_ALWAYS_THROWING_UNREACHABLE_END
         requires
             (!std::is_same_v<rvariant<Us...>, rvariant>) &&
             rvariant_set::subset_of<rvariant<Us...>, rvariant> &&
-            (!std::disjunction_v<std::is_same<rvariant<Us...>, unwrap_recursive_t<Ts>>...>) &&
-            std::conjunction_v<std::is_constructible<detail::select_maybe_wrapped_t<unwrap_recursive_t<Us>, Ts...>, Us const&>...>
+            (!std::disjunction_v<std::is_same<rvariant<Us...>, unwrap_recursive_type<Ts>>...>) &&
+            std::conjunction_v<std::is_constructible<detail::select_maybe_wrapped_t<unwrap_recursive_type<Us>, Ts...>, Us const&>...>
     constexpr rvariant(rvariant<Us...> const& w)
-        noexcept(std::conjunction_v<std::is_nothrow_constructible<detail::select_maybe_wrapped_t<unwrap_recursive_t<Us>, Ts...>, Us const&>...>)
+        noexcept(std::conjunction_v<std::is_nothrow_constructible<detail::select_maybe_wrapped_t<unwrap_recursive_type<Us>, Ts...>, Us const&>...>)
     {
         w.raw_visit([this]<std::size_t j, class Uj>(std::in_place_index_t<j>, [[maybe_unused]] Uj const& uj)
-            noexcept(std::conjunction_v<std::is_nothrow_constructible<detail::select_maybe_wrapped_t<unwrap_recursive_t<Us>, Ts...>, Us const&>...>)
+            noexcept(std::conjunction_v<std::is_nothrow_constructible<detail::select_maybe_wrapped_t<unwrap_recursive_type<Us>, Ts...>, Us const&>...>)
         {
             if constexpr (j != std::variant_npos) {
-                using maybe_wrapped = detail::select_maybe_wrapped<unwrap_recursive_t<Uj>, Ts...>;
+                using maybe_wrapped = detail::select_maybe_wrapped<unwrap_recursive_type<Uj>, Ts...>;
                 using VT = maybe_wrapped::type;
-                static_assert(std::is_same_v<unwrap_recursive_t<VT>, unwrap_recursive_t<Uj>>);
+                static_assert(std::is_same_v<unwrap_recursive_type<VT>, unwrap_recursive_type<Uj>>);
                 base_type::template construct_on_valueless<maybe_wrapped::index>(detail::forward_maybe_wrapped<VT>(uj));
             }
         });
@@ -608,18 +608,18 @@ IRIS_RVARIANT_ALWAYS_THROWING_UNREACHABLE_END
         requires
             (!std::is_same_v<rvariant<Us...>, rvariant>) &&
             rvariant_set::subset_of<rvariant<Us...>, rvariant> &&
-            (!std::disjunction_v<std::is_same<rvariant<Us...>, unwrap_recursive_t<Ts>>...>) &&
-            std::conjunction_v<std::is_constructible<detail::select_maybe_wrapped_t<unwrap_recursive_t<Us>, Ts...>, Us&&>...>
+            (!std::disjunction_v<std::is_same<rvariant<Us...>, unwrap_recursive_type<Ts>>...>) &&
+            std::conjunction_v<std::is_constructible<detail::select_maybe_wrapped_t<unwrap_recursive_type<Us>, Ts...>, Us&&>...>
     constexpr rvariant(rvariant<Us...>&& w)
-        noexcept(std::conjunction_v<std::is_nothrow_constructible<detail::select_maybe_wrapped_t<unwrap_recursive_t<Us>, Ts...>, Us&&>...>)
+        noexcept(std::conjunction_v<std::is_nothrow_constructible<detail::select_maybe_wrapped_t<unwrap_recursive_type<Us>, Ts...>, Us&&>...>)
     {
         std::move(w).raw_visit([this]<std::size_t j, class Uj>(std::in_place_index_t<j>, [[maybe_unused]] Uj&& uj)
-            noexcept(std::conjunction_v<std::is_nothrow_constructible<detail::select_maybe_wrapped_t<unwrap_recursive_t<Us>, Ts...>, Us&&>...>)
+            noexcept(std::conjunction_v<std::is_nothrow_constructible<detail::select_maybe_wrapped_t<unwrap_recursive_type<Us>, Ts...>, Us&&>...>)
         {
             if constexpr (j != std::variant_npos) {
-                using maybe_wrapped = detail::select_maybe_wrapped<unwrap_recursive_t<Uj>, Ts...>;
+                using maybe_wrapped = detail::select_maybe_wrapped<unwrap_recursive_type<Uj>, Ts...>;
                 using VT = maybe_wrapped::type;
-                static_assert(std::is_same_v<unwrap_recursive_t<VT>, unwrap_recursive_t<Uj>>);
+                static_assert(std::is_same_v<unwrap_recursive_type<VT>, unwrap_recursive_type<Uj>>);
                 static_assert(std::is_rvalue_reference_v<Uj&&>);
                 base_type::template construct_on_valueless<maybe_wrapped::index>(detail::forward_maybe_wrapped<VT>(std::move(uj))); // NOLINT(bugprone-move-forwarding-reference)
             }
@@ -633,30 +633,30 @@ IRIS_RVARIANT_ALWAYS_THROWING_UNREACHABLE_END
         requires
             (!std::is_same_v<rvariant<Us...>, rvariant>) &&
             rvariant_set::subset_of<rvariant<Us...>, rvariant> &&
-            (!std::disjunction_v<std::is_same<rvariant<Us...>, unwrap_recursive_t<Ts>>...>) &&
-            std::conjunction_v<detail::variant_copy_assignable<detail::select_maybe_wrapped_t<unwrap_recursive_t<Us>, Ts...>, Us const&>...>
+            (!std::disjunction_v<std::is_same<rvariant<Us...>, unwrap_recursive_type<Ts>>...>) &&
+            std::conjunction_v<detail::variant_copy_assignable<detail::select_maybe_wrapped_t<unwrap_recursive_type<Us>, Ts...>, Us const&>...>
     constexpr rvariant& operator=(rvariant<Us...> const& rhs)
-        noexcept(std::conjunction_v<detail::variant_nothrow_copy_assignable<detail::select_maybe_wrapped_t<unwrap_recursive_t<Us>, Ts...>, Us const&>...>)
+        noexcept(std::conjunction_v<detail::variant_nothrow_copy_assignable<detail::select_maybe_wrapped_t<unwrap_recursive_type<Us>, Ts...>, Us const&>...>)
     {
         rhs.raw_visit([this]<std::size_t j, class Uj>(std::in_place_index_t<j>, [[maybe_unused]] Uj const& uj)
-            noexcept(std::conjunction_v<detail::variant_nothrow_copy_assignable<detail::select_maybe_wrapped_t<unwrap_recursive_t<Us>, Ts...>, Us const&>...>)
+            noexcept(std::conjunction_v<detail::variant_nothrow_copy_assignable<detail::select_maybe_wrapped_t<unwrap_recursive_type<Us>, Ts...>, Us const&>...>)
         {
             if constexpr (j == std::variant_npos) {
                 this->visit_reset();
 
             } else {
-                using maybe_wrapped = detail::select_maybe_wrapped<unwrap_recursive_t<Uj>, Ts...>;
+                using maybe_wrapped = detail::select_maybe_wrapped<unwrap_recursive_type<Uj>, Ts...>;
                 using VT = maybe_wrapped::type;
-                static_assert(std::is_same_v<unwrap_recursive_t<VT>, unwrap_recursive_t<Uj>>);
+                static_assert(std::is_same_v<unwrap_recursive_type<VT>, unwrap_recursive_type<Uj>>);
 
                 this->raw_visit([this, &uj]<std::size_t i, class Ti>(std::in_place_index_t<i>, [[maybe_unused]] Ti& ti)
-                    noexcept(std::conjunction_v<detail::variant_nothrow_copy_assignable<detail::select_maybe_wrapped_t<unwrap_recursive_t<Us>, Ts...>, Us const&>...>)
+                    noexcept(std::conjunction_v<detail::variant_nothrow_copy_assignable<detail::select_maybe_wrapped_t<unwrap_recursive_type<Us>, Ts...>, Us const&>...>)
                 {
                     constexpr std::size_t VTi = maybe_wrapped::index;
                     if constexpr (i == std::variant_npos) { // this is valueless, rhs holds value
                         base_type::template construct_on_valueless<VTi>(detail::forward_maybe_wrapped<VT>(uj));
 
-                    } else if constexpr (std::is_same_v<unwrap_recursive_t<Ti>, unwrap_recursive_t<Uj>>) {
+                    } else if constexpr (std::is_same_v<unwrap_recursive_type<Ti>, unwrap_recursive_type<Uj>>) {
                         ti = detail::forward_maybe_wrapped<Ti>(uj);
 
                     } else if constexpr (std::is_nothrow_constructible_v<VT, Uj const&> || !std::is_nothrow_move_constructible_v<VT>) {
@@ -677,31 +677,31 @@ IRIS_RVARIANT_ALWAYS_THROWING_UNREACHABLE_END
         requires
             (!std::is_same_v<rvariant<Us...>, rvariant>) &&
             rvariant_set::subset_of<rvariant<Us...>, rvariant> &&
-            (!std::disjunction_v<std::is_same<rvariant<Us...>, unwrap_recursive_t<Ts>>...>) &&
-            std::conjunction_v<detail::variant_move_assignable<detail::select_maybe_wrapped_t<unwrap_recursive_t<Us>, Ts...>, Us&&>...>
+            (!std::disjunction_v<std::is_same<rvariant<Us...>, unwrap_recursive_type<Ts>>...>) &&
+            std::conjunction_v<detail::variant_move_assignable<detail::select_maybe_wrapped_t<unwrap_recursive_type<Us>, Ts...>, Us&&>...>
     constexpr rvariant& operator=(rvariant<Us...>&& rhs)
-        noexcept(std::conjunction_v<detail::variant_nothrow_move_assignable<detail::select_maybe_wrapped_t<unwrap_recursive_t<Us>, Ts...>, Us&&>...>)
+        noexcept(std::conjunction_v<detail::variant_nothrow_move_assignable<detail::select_maybe_wrapped_t<unwrap_recursive_type<Us>, Ts...>, Us&&>...>)
     {
         std::move(rhs).raw_visit([this]<std::size_t j, class Uj>(std::in_place_index_t<j>, [[maybe_unused]] Uj&& uj)
-            noexcept(std::conjunction_v<detail::variant_nothrow_move_assignable<detail::select_maybe_wrapped_t<unwrap_recursive_t<Us>, Ts...>, Us&&>...>)
+            noexcept(std::conjunction_v<detail::variant_nothrow_move_assignable<detail::select_maybe_wrapped_t<unwrap_recursive_type<Us>, Ts...>, Us&&>...>)
         {
             if constexpr (j == std::variant_npos) {
                 this->visit_reset();
 
             } else {
-                using maybe_wrapped = detail::select_maybe_wrapped<unwrap_recursive_t<Uj>, Ts...>;
+                using maybe_wrapped = detail::select_maybe_wrapped<unwrap_recursive_type<Uj>, Ts...>;
                 using VT = maybe_wrapped::type;
-                static_assert(std::is_same_v<unwrap_recursive_t<VT>, unwrap_recursive_t<Uj>>);
+                static_assert(std::is_same_v<unwrap_recursive_type<VT>, unwrap_recursive_type<Uj>>);
 
                 this->raw_visit([this, &uj]<std::size_t i, class Ti>(std::in_place_index_t<i>, [[maybe_unused]] Ti& ti)
-                    noexcept(std::conjunction_v<detail::variant_nothrow_move_assignable<detail::select_maybe_wrapped_t<unwrap_recursive_t<Us>, Ts...>, Us&&>...>)
+                    noexcept(std::conjunction_v<detail::variant_nothrow_move_assignable<detail::select_maybe_wrapped_t<unwrap_recursive_type<Us>, Ts...>, Us&&>...>)
                 {
                     static_assert(std::is_rvalue_reference_v<Uj&&>);
                     constexpr std::size_t VTi = maybe_wrapped::index;
                     if constexpr (i == std::variant_npos) { // this is valueless, rhs holds value
                         base_type::template construct_on_valueless<VTi>(detail::forward_maybe_wrapped<VT>(std::move(uj)));  // NOLINT(bugprone-move-forwarding-reference)
 
-                    } else if constexpr (std::is_same_v<unwrap_recursive_t<Ti>, unwrap_recursive_t<Uj>>) {
+                    } else if constexpr (std::is_same_v<unwrap_recursive_type<Ti>, unwrap_recursive_type<Uj>>) {
                         ti = detail::forward_maybe_wrapped<Ti>(std::move(uj)); // NOLINT(bugprone-move-forwarding-reference)
 
                     } else {
@@ -1113,7 +1113,7 @@ get(rvariant<Ts...>& v IRIS_LIFETIMEBOUND)
 {
     static_assert(I < sizeof...(Ts));
     if (v.index() == I) {
-        return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&>(v)));
+        return unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&>(v)));
     }
     detail::throw_bad_variant_access();
 }
@@ -1124,7 +1124,7 @@ get(rvariant<Ts...>&& v IRIS_LIFETIMEBOUND)  // NOLINT(cppcoreguidelines-rvalue-
 {
     static_assert(I < sizeof...(Ts));
     if (v.index() == I) {
-        return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&&>(v)));
+        return unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&&>(v)));
     }
     detail::throw_bad_variant_access();
 }
@@ -1135,7 +1135,7 @@ get(rvariant<Ts...> const& v IRIS_LIFETIMEBOUND)
 {
     static_assert(I < sizeof...(Ts));
     if (v.index() == I) {
-        return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&>(v)));
+        return unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&>(v)));
     }
     detail::throw_bad_variant_access();
 }
@@ -1146,7 +1146,7 @@ get(rvariant<Ts...> const&& v IRIS_LIFETIMEBOUND)
 {
     static_assert(I < sizeof...(Ts));
     if (v.index() == I) {
-        return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&&>(v)));
+        return unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&&>(v)));
     }
     detail::throw_bad_variant_access();
 }
@@ -1157,7 +1157,7 @@ get(rvariant<Ts...>& v IRIS_LIFETIMEBOUND)
 {
     constexpr std::size_t I = detail::exactly_once_index_v<T, rvariant<Ts...>>;
     if (v.index() == I) {
-        return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&>(v)));
+        return unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&>(v)));
     }
     detail::throw_bad_variant_access();
 }
@@ -1168,7 +1168,7 @@ get(rvariant<Ts...>&& v IRIS_LIFETIMEBOUND)  // NOLINT(cppcoreguidelines-rvalue-
 {
     constexpr std::size_t I = detail::exactly_once_index_v<T, rvariant<Ts...>>;
     if (v.index() == I) {
-        return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&&>(v)));
+        return unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&&>(v)));
     }
     detail::throw_bad_variant_access();
 }
@@ -1179,7 +1179,7 @@ get(rvariant<Ts...> const& v IRIS_LIFETIMEBOUND)
 {
     constexpr std::size_t I = detail::exactly_once_index_v<T, rvariant<Ts...>>;
     if (v.index() == I) {
-        return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&>(v)));
+        return unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&>(v)));
     }
     detail::throw_bad_variant_access();
 }
@@ -1190,7 +1190,7 @@ get(rvariant<Ts...> const&& v IRIS_LIFETIMEBOUND)
 {
     constexpr std::size_t I = detail::exactly_once_index_v<T, rvariant<Ts...>>;
     if (v.index() == I) {
-        return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&&>(v)));
+        return unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&&>(v)));
     }
     detail::throw_bad_variant_access();
 }
@@ -1218,7 +1218,7 @@ template<std::size_t I, class... Ts>
 unsafe_get(rvariant<Ts...>& v IRIS_LIFETIMEBOUND) noexcept
 {
     static_assert(I < sizeof...(Ts));
-    return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&>(v)));
+    return unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&>(v)));
 }
 
 template<std::size_t I, class... Ts>
@@ -1226,7 +1226,7 @@ template<std::size_t I, class... Ts>
 unsafe_get(rvariant<Ts...>&& v IRIS_LIFETIMEBOUND) noexcept  // NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
 {
     static_assert(I < sizeof...(Ts));
-    return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&&>(v)));
+    return unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&&>(v)));
 }
 
 template<std::size_t I, class... Ts>
@@ -1234,14 +1234,14 @@ template<std::size_t I, class... Ts>
 unsafe_get(rvariant<Ts...> const& v IRIS_LIFETIMEBOUND) noexcept
 {
     static_assert(I < sizeof...(Ts));
-    return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&>(v)));
+    return unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&>(v)));
 }
 
 template<std::size_t I, class... Ts>
 [[nodiscard]] constexpr variant_alternative_t<I, rvariant<Ts...>> const&&
 unsafe_get(rvariant<Ts...> const&& v IRIS_LIFETIMEBOUND) noexcept
 {
-    return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&&>(v)));
+    return unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&&>(v)));
 }
 
 template<class T, class... Ts>
@@ -1249,7 +1249,7 @@ template<class T, class... Ts>
 unsafe_get(rvariant<Ts...>& v IRIS_LIFETIMEBOUND) noexcept
 {
     constexpr std::size_t I = detail::exactly_once_index_v<T, rvariant<Ts...>>;
-    return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&>(v)));
+    return unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&>(v)));
 }
 
 template<class T, class... Ts>
@@ -1257,7 +1257,7 @@ template<class T, class... Ts>
 unsafe_get(rvariant<Ts...>&& v IRIS_LIFETIMEBOUND) noexcept  // NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
 {
     constexpr std::size_t I = detail::exactly_once_index_v<T, rvariant<Ts...>>;
-    return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&&>(v)));
+    return unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&&>(v)));
 }
 
 template<class T, class... Ts>
@@ -1265,7 +1265,7 @@ template<class T, class... Ts>
 unsafe_get(rvariant<Ts...> const& v IRIS_LIFETIMEBOUND) noexcept
 {
     constexpr std::size_t I = detail::exactly_once_index_v<T, rvariant<Ts...>>;
-    return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&>(v)));
+    return unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&>(v)));
 }
 
 template<class T, class... Ts>
@@ -1273,7 +1273,7 @@ template<class T, class... Ts>
 unsafe_get(rvariant<Ts...> const&& v IRIS_LIFETIMEBOUND) noexcept
 {
     constexpr std::size_t I = detail::exactly_once_index_v<T, rvariant<Ts...>>;
-    return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&&>(v)));
+    return unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&&>(v)));
 }
 
 template<class T, class... Ts>
@@ -1300,7 +1300,7 @@ get_if(rvariant<Ts...>* v) noexcept
 {
     static_assert(I < sizeof...(Ts));
     return v && v->index() == I
-        ? std::addressof(detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&>(*v))))
+        ? std::addressof(unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&>(*v))))
         : nullptr;
 }
 
@@ -1310,7 +1310,7 @@ get_if(rvariant<Ts...> const* v) noexcept
 {
     static_assert(I < sizeof...(Ts));
     return v && v->index() == I
-        ? std::addressof(detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&>(*v))))
+        ? std::addressof(unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&>(*v))))
         : nullptr;
 }
 

--- a/include/iris/rvariant/rvariant_io.hpp
+++ b/include/iris/rvariant/rvariant_io.hpp
@@ -46,7 +46,7 @@ template<class... Ts>
         // Required to work around MSVC bug where it instantiates this function
         // for completely irrelevant call, e.g. `std::cout << "foo"sv << 'c' << std::endl;`
         (sizeof...(Ts) > 0) &&
-        std::conjunction_v<req::ADL_ostreamable<unwrap_recursive_t<Ts>>...>
+        std::conjunction_v<req::ADL_ostreamable<unwrap_recursive_type<Ts>>...>
 std::ostream& operator<<(std::ostream& os, rvariant<Ts...> const& v)
 {
     std::ostream::sentry sentry(os);
@@ -65,7 +65,7 @@ std::ostream& operator<<(std::ostream& os, rvariant<Ts...> const& v)
             if constexpr (i == std::variant_npos) {
                 std::unreachable();
             } else {
-                os << detail::unwrap_recursive(o); // NOTE: this may also throw `std::bad_variant_access`
+                os << unwrap_recursive(o); // NOTE: this may also throw `std::bad_variant_access`
             }
         });
 
@@ -181,7 +181,7 @@ struct variant_alts_formattable : std::false_type
 
 template<class charT, class... Ts>
 struct variant_alts_formattable<charT, rvariant<Ts...>>
-    : std::bool_constant<(std::formattable<unwrap_recursive_t<Ts>, charT> && ...)>
+    : std::bool_constant<(std::formattable<unwrap_recursive_type<Ts>, charT> && ...)>
 {};
 
 } // detail
@@ -192,7 +192,7 @@ struct variant_alts_formattable<charT, rvariant<Ts...>>
 namespace std {
 
 template<class... Ts, class charT>
-    requires (std::formattable<::iris::unwrap_recursive_t<Ts>, charT> && ...)
+    requires (std::formattable<::iris::unwrap_recursive_type<Ts>, charT> && ...)
 struct formatter<::iris::rvariant<Ts...>, charT>  // NOLINT(cert-dcl58-cpp)
 {
     static constexpr typename std::basic_format_parse_context<charT>::const_iterator
@@ -219,8 +219,8 @@ struct formatter<::iris::rvariant<Ts...>, charT>  // NOLINT(cert-dcl58-cpp)
                 } else {
                     return std::format_to(
                         ctx.out(),
-                        ::iris::format_traits<charT>::template brace_full<::iris::unwrap_recursive_t<VT> const&>,
-                        ::iris::detail::unwrap_recursive(alt)
+                        ::iris::format_traits<charT>::template brace_full<::iris::unwrap_recursive_type<VT> const&>,
+                        ::iris::unwrap_recursive(alt)
                     );
                 }
             }
@@ -257,13 +257,13 @@ struct formatter<::iris::detail::variant_format_proxy<VFormat, Variant>, charT> 
                     ::iris::detail::throw_bad_variant_access();
                 } else {
                     static_assert(
-                        std::is_invocable_v<VFormat, std::in_place_type_t<::iris::unwrap_recursive_t<VT>>>,
+                        std::is_invocable_v<VFormat, std::in_place_type_t<::iris::unwrap_recursive_type<VT>>>,
                         "`VFormat` must provide format string for all alternative types."
                     );
                     return std::format_to(
                         ctx.out(),
-                        std::invoke(proxy.v_fmt, std::in_place_type<::iris::unwrap_recursive_t<VT>>),
-                        ::iris::detail::unwrap_recursive(alt)
+                        std::invoke(proxy.v_fmt, std::in_place_type<::iris::unwrap_recursive_type<VT>>),
+                        ::iris::unwrap_recursive(alt)
                     );
                 }
             }

--- a/include/iris/rvariant/subset.hpp
+++ b/include/iris/rvariant/subset.hpp
@@ -47,7 +47,7 @@ struct is_subset_of<rvariant<Us...>, rvariant<Ts...>>
     : std::conjunction<
         std::disjunction<
             is_in<Us, Ts...>,
-            is_in<Us, unwrap_recursive_t<Ts>...>
+            is_in<Us, unwrap_recursive_type<Ts>...>
         >...
     >
 {};

--- a/test/rvariant/rvariant.cpp
+++ b/test/rvariant/rvariant.cpp
@@ -1589,15 +1589,15 @@ TEST_CASE("recursive_wrapper") // not [recursive]
 
 TEST_CASE("unwrap_recursive") // not [recursive]
 {
-    STATIC_REQUIRE(std::is_same_v<decltype(iris::detail::unwrap_recursive(std::declval<int&>())), int&>);
-    STATIC_REQUIRE(std::is_same_v<decltype(iris::detail::unwrap_recursive(std::declval<int&&>())), int&&>);
-    STATIC_REQUIRE(std::is_same_v<decltype(iris::detail::unwrap_recursive(std::declval<int const&>())), int const&>);
-    STATIC_REQUIRE(std::is_same_v<decltype(iris::detail::unwrap_recursive(std::declval<int const&&>())), int const&&>);
+    STATIC_REQUIRE(std::is_same_v<decltype(iris::unwrap_recursive(std::declval<int&>())), int&>);
+    STATIC_REQUIRE(std::is_same_v<decltype(iris::unwrap_recursive(std::declval<int&&>())), int&&>);
+    STATIC_REQUIRE(std::is_same_v<decltype(iris::unwrap_recursive(std::declval<int const&>())), int const&>);
+    STATIC_REQUIRE(std::is_same_v<decltype(iris::unwrap_recursive(std::declval<int const&&>())), int const&&>);
 
-    STATIC_REQUIRE(std::is_same_v<decltype(iris::detail::unwrap_recursive(std::declval<iris::recursive_wrapper<int>&>())), int&>);
-    STATIC_REQUIRE(std::is_same_v<decltype(iris::detail::unwrap_recursive(std::declval<iris::recursive_wrapper<int>&&>())), int&&>);
-    STATIC_REQUIRE(std::is_same_v<decltype(iris::detail::unwrap_recursive(std::declval<iris::recursive_wrapper<int> const&>())), int const&>);
-    STATIC_REQUIRE(std::is_same_v<decltype(iris::detail::unwrap_recursive(std::declval<iris::recursive_wrapper<int> const&&>())), int const&&>);
+    STATIC_REQUIRE(std::is_same_v<decltype(iris::unwrap_recursive(std::declval<iris::recursive_wrapper<int>&>())), int&>);
+    STATIC_REQUIRE(std::is_same_v<decltype(iris::unwrap_recursive(std::declval<iris::recursive_wrapper<int>&&>())), int&&>);
+    STATIC_REQUIRE(std::is_same_v<decltype(iris::unwrap_recursive(std::declval<iris::recursive_wrapper<int> const&>())), int const&>);
+    STATIC_REQUIRE(std::is_same_v<decltype(iris::unwrap_recursive(std::declval<iris::recursive_wrapper<int> const&&>())), int const&&>);
 }
 
 TEST_CASE("maybe_wrapped") // not [recursive]


### PR DESCRIPTION
During the adaptation of rvariant in X4 (iris-cpp/x4#9), it turned out that _`UNWRAP_RECURSIVE`_ is actually needed on a user-facing interface.

In-depth rationale: https://github.com/iris-cpp/x4/blob/6e4a46f258c685883aa3b5a4bdbc0886a6e459de/include/iris/x4/traits/variant_traits.hpp#L52-L65

This PR is the requirement for adding such optimization to X4.

### Changes

- `struct unwrap_recursive`
  - Removed as being very niche use case
- `using unwrap_recursive_t = ...`
  - Renamed to `unwrap_recursive_type`
- _`UNWRAP_RECURSIVE`_
  - Previously exposition-only, now public API
  - Revised into `iris::unwrap_recursive`