### PR TITLE
Fix the semantics of `operator=(variant(rhs))` specified in [variant.assign]/2.5

### DIFF
--- a/include/iris/rvariant/rvariant.hpp
+++ b/include/iris/rvariant/rvariant.hpp
@@ -139,7 +139,7 @@ IRIS_RVARIANT_ALWAYS_THROWING_UNREACHABLE_END
                     if constexpr (std::is_nothrow_copy_constructible_v<T> || !std::is_nothrow_move_constructible_v<T>) {
                         reset_construct<j>(rhs_alt);  // A
                     } else {
-                        auto tmp = rhs_alt;
+                        T tmp(rhs_alt);
                         reset_construct<j>(std::move(tmp)); // B
                     }
                 }

--- a/test/rvariant/rvariant.cpp
+++ b/test/rvariant/rvariant.cpp
@@ -1061,6 +1061,24 @@ TEST_CASE("copy assignment")
         CHECK(a.valueless_by_exception() == true);
     }
 
+    {
+        // see https://github.com/microsoft/STL/issues/6085
+        struct S {
+            S() noexcept = default;
+
+            explicit S(S const&) noexcept(false) = default;
+            S(S&&) noexcept = default;
+
+            S& operator=(S const&) noexcept { return *this; }
+            S& operator=(S&&) noexcept = default;
+        };
+
+        iris::rvariant<int, S> a = 42;
+        iris::rvariant<int, S> b = S{};
+        a = b;
+        REQUIRE(a.index() == 1);
+    }
+
     // NOLINTEND(modernize-use-equals-default)
 }
 


### PR DESCRIPTION
Discussed in online, fixing potential `rejects-valid` issue.

related issue https://github.com/microsoft/STL/issues/6085

https://eel.is/c++draft/variant#assign-2.5