### PR TITLE
Add `is_convertible_without_narrowing`

### DIFF
--- a/include/iris/rvariant/rvariant.hpp
+++ b/include/iris/rvariant/rvariant.hpp
@@ -620,10 +620,10 @@ public:
             (!std::is_same_v<std::remove_cvref_t<T>, rvariant>) &&
             (!is_ttp_specialization_of_v<std::remove_cvref_t<T>, std::in_place_type_t>) &&
             (!is_ctp_specialization_of_v<std::remove_cvref_t<T>, std::in_place_index_t>) &&
-            std::is_constructible_v<typename aggregate_initialize_resolution<T, Ts...>::type, T>
+            std::is_constructible_v<typename no_narrowing_resolution<T, Ts...>::type, T>
     constexpr /* not explicit */ rvariant(T&& t)
-        noexcept(std::is_nothrow_constructible_v<typename aggregate_initialize_resolution<T, Ts...>::type, T>)
-        : base_type(std::in_place_index<aggregate_initialize_resolution<T, Ts...>::index>, std::forward<T>(t))
+        noexcept(std::is_nothrow_constructible_v<typename no_narrowing_resolution<T, Ts...>::type, T>)
+        : base_type(std::in_place_index<no_narrowing_resolution<T, Ts...>::index>, std::forward<T>(t))
     {}
 
 IRIS_RVARIANT_ALWAYS_THROWING_UNREACHABLE_BEGIN
@@ -632,12 +632,12 @@ IRIS_RVARIANT_ALWAYS_THROWING_UNREACHABLE_BEGIN
     template<class T>
         requires
             (!std::is_same_v<std::remove_cvref_t<T>, rvariant>) &&
-            detail::variant_assignable<typename aggregate_initialize_resolution<T, Ts...>::type, T>::value
+            detail::variant_assignable<typename no_narrowing_resolution<T, Ts...>::type, T>::value
     constexpr rvariant& operator=(T&& t)
-        noexcept(detail::variant_nothrow_assignable<typename aggregate_initialize_resolution<T, Ts...>::type, T>::value)
+        noexcept(detail::variant_nothrow_assignable<typename no_narrowing_resolution<T, Ts...>::type, T>::value)
     {
-        using Tj = aggregate_initialize_resolution<T, Ts...>::type; // either plain type or wrapped with recursive_wrapper
-        constexpr std::size_t j = aggregate_initialize_resolution<T, Ts...>::index;
+        using Tj = no_narrowing_resolution<T, Ts...>::type; // either plain type or wrapped with recursive_wrapper
+        constexpr std::size_t j = no_narrowing_resolution<T, Ts...>::index;
         static_assert(j != std::variant_npos);
 
         this->raw_visit([this, &t]<std::size_t i, class Ti>(std::in_place_index_t<i>, [[maybe_unused]] Ti& ti)

--- a/include/iris/rvariant/rvariant.hpp
+++ b/include/iris/rvariant/rvariant.hpp
@@ -620,10 +620,10 @@ public:
             (!std::is_same_v<std::remove_cvref_t<T>, rvariant>) &&
             (!is_ttp_specialization_of_v<std::remove_cvref_t<T>, std::in_place_type_t>) &&
             (!is_ctp_specialization_of_v<std::remove_cvref_t<T>, std::in_place_index_t>) &&
-            std::is_constructible_v<typename no_narrowing_resolution<T, Ts...>::type, T>
+            std::is_constructible_v<typename aggregate_initialize_resolution<T, Ts...>::type, T>
     constexpr /* not explicit */ rvariant(T&& t)
-        noexcept(std::is_nothrow_constructible_v<typename no_narrowing_resolution<T, Ts...>::type, T>)
-        : base_type(std::in_place_index<no_narrowing_resolution<T, Ts...>::index>, std::forward<T>(t))
+        noexcept(std::is_nothrow_constructible_v<typename aggregate_initialize_resolution<T, Ts...>::type, T>)
+        : base_type(std::in_place_index<aggregate_initialize_resolution<T, Ts...>::index>, std::forward<T>(t))
     {}
 
 IRIS_RVARIANT_ALWAYS_THROWING_UNREACHABLE_BEGIN
@@ -632,12 +632,12 @@ IRIS_RVARIANT_ALWAYS_THROWING_UNREACHABLE_BEGIN
     template<class T>
         requires
             (!std::is_same_v<std::remove_cvref_t<T>, rvariant>) &&
-            detail::variant_assignable<typename no_narrowing_resolution<T, Ts...>::type, T>::value
+            detail::variant_assignable<typename aggregate_initialize_resolution<T, Ts...>::type, T>::value
     constexpr rvariant& operator=(T&& t)
-        noexcept(detail::variant_nothrow_assignable<typename no_narrowing_resolution<T, Ts...>::type, T>::value)
+        noexcept(detail::variant_nothrow_assignable<typename aggregate_initialize_resolution<T, Ts...>::type, T>::value)
     {
-        using Tj = no_narrowing_resolution<T, Ts...>::type; // either plain type or wrapped with recursive_wrapper
-        constexpr std::size_t j = no_narrowing_resolution<T, Ts...>::index;
+        using Tj = aggregate_initialize_resolution<T, Ts...>::type; // either plain type or wrapped with recursive_wrapper
+        constexpr std::size_t j = aggregate_initialize_resolution<T, Ts...>::index;
         static_assert(j != std::variant_npos);
 
         this->raw_visit([this, &t]<std::size_t i, class Ti>(std::in_place_index_t<i>, [[maybe_unused]] Ti& ti)

--- a/include/iris/type_traits.hpp
+++ b/include/iris/type_traits.hpp
@@ -241,6 +241,24 @@ template<class From, class To>
 inline constexpr bool is_convertible_without_narrowing_v = is_convertible_without_narrowing<From, To>::value;
 
 
+// is_assignable_without_narrowing<Dest, Source>
+//
+// True when `Dest = Source` is valid AND does not involve a narrowing conversion.
+// For non-arithmetic Dest types, narrowing is not checked — we trust that the
+// user-defined conversion handles the assignment correctly.
+template<class Dest, class Source>
+struct is_assignable_without_narrowing
+    : std::bool_constant<
+        std::is_assignable_v<Dest, Source> &&
+        (!std::is_arithmetic_v<std::remove_reference_t<Dest>> ||
+         is_convertible_without_narrowing_v<std::remove_cvref_t<Source>, std::remove_reference_t<Dest>>)
+    >
+{};
+
+template<class Dest, class Source>
+inline constexpr bool is_assignable_without_narrowing_v = is_assignable_without_narrowing<Dest, Source>::value;
+
+
 namespace detail {
 
 template<std::size_t I, class Ti>

--- a/include/iris/type_traits.hpp
+++ b/include/iris/type_traits.hpp
@@ -272,10 +272,10 @@ struct aggregate_initialize_tag
 };
 
 template<std::size_t I, class Ti>
-struct no_narrowing_overload
+struct aggregate_initialize_overload
 {
     template<class T>
-    auto operator()(T&&) -> aggregate_initialize_tag<I, Ti>
+    auto operator()(Ti, T&&) -> aggregate_initialize_tag<I, Ti>
         requires is_convertible_without_narrowing_v<T, Ti>
     {
         return {}; // silence MSVC warning
@@ -283,27 +283,26 @@ struct no_narrowing_overload
 };
 
 template<class Is, class... Ts>
-struct no_narrowing_fun;
+struct aggregate_initialize_fun;
 
 // Imaginary function FUN of https://eel.is/c++draft/variant#ctor-14
 template<std::size_t... Is, class... Ts>
-struct no_narrowing_fun<std::index_sequence<Is...>, Ts...>
-    : no_narrowing_overload<Is, Ts>...
+struct aggregate_initialize_fun<std::index_sequence<Is...>, Ts...>
+    : aggregate_initialize_overload<Is, Ts>...
 {
-    using no_narrowing_overload<Is, Ts>::operator()...;
+    using aggregate_initialize_overload<Is, Ts>::operator()...;
 };
 
 template<class... Ts>
-using aggregate_initialize_fun_for = no_narrowing_fun<std::index_sequence_for<Ts...>, Ts...>;
+using aggregate_initialize_fun_for = aggregate_initialize_fun<std::index_sequence_for<Ts...>, Ts...>;
 
 template<class Enabled, class T, class... Ts>
-struct no_narrowing_resolution {};
+struct aggregate_initialize_resolution {};
 
 template<class T, class... Ts>
-struct no_narrowing_resolution<
+struct aggregate_initialize_resolution<
     std::void_t<decltype(aggregate_initialize_fun_for<Ts...>{}(std::declval<T>(), std::declval<T>()))>, T, Ts...
->
-{
+> {
     using tag = decltype(aggregate_initialize_fun_for<Ts...>{}(std::declval<T>(), std::declval<T>()));
     using type = tag::type;
     static constexpr std::size_t index = tag::index;
@@ -315,7 +314,7 @@ struct no_narrowing_resolution<
 // because they would lead to unnecessarily nested instantiation for
 // legitimate infinite recursion errors on recursive types.
 template<class T, class... Ts>
-struct no_narrowing_resolution : detail::no_narrowing_resolution<void, T, Ts...> {};
+struct aggregate_initialize_resolution : detail::aggregate_initialize_resolution<void, T, Ts...> {};
 
 } // iris
 

--- a/include/iris/type_traits.hpp
+++ b/include/iris/type_traits.hpp
@@ -244,8 +244,13 @@ inline constexpr bool is_convertible_without_narrowing_v = is_convertible_withou
 // is_assignable_without_narrowing<Dest, Source>
 //
 // True when `Dest = Source` is valid AND does not involve a narrowing conversion.
-// For non-arithmetic Dest types, narrowing is not checked — we trust that the
-// user-defined conversion handles the assignment correctly.
+//
+// The arithmetic guard is intentional: narrowing conversions are only defined for
+// arithmetic types ([dcl.init.list]), and the underlying `is_convertible_without_narrowing`
+// uses brace-initialization (`To[]{from}`) which may select a different construction
+// path than what `is_assignable` tests (e.g. initializer_list hijacking). Restricting
+// the narrowing check to arithmetic Dest avoids false rejections for non-arithmetic
+// types where the brace-init semantics diverge from assignment semantics.
 template<class Dest, class Source>
 struct is_assignable_without_narrowing
     : std::bool_constant<

--- a/include/iris/type_traits.hpp
+++ b/include/iris/type_traits.hpp
@@ -222,6 +222,25 @@ template<class T>
 constexpr bool is_trivially_swappable_v = is_trivially_swappable<T>::value;
 
 
+// P0870R7: is_convertible_without_narrowing
+// https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p0870r7.html
+template<class From, class To>
+struct is_convertible_without_narrowing
+    : std::false_type
+{};
+
+template<class From, class To>
+    requires
+        std::is_convertible_v<From, To> &&
+        requires { std::type_identity_t<To[]>{std::declval<From>()}; }
+struct is_convertible_without_narrowing<From, To>
+    : std::true_type
+{};
+
+template<class From, class To>
+inline constexpr bool is_convertible_without_narrowing_v = is_convertible_without_narrowing<From, To>::value;
+
+
 namespace detail {
 
 template<std::size_t I, class Ti>
@@ -231,19 +250,12 @@ struct aggregate_initialize_tag
     using type = Ti;
 };
 
-// This version works better than MSVC's, does not break IntelliSense or ReSharper
 template<std::size_t I, class Ti>
 struct aggregate_initialize_overload
 {
-    using TiA = Ti[];
-
-    // https://eel.is/c++draft/dcl.init.general#14
-    // https://eel.is/c++draft/dcl.init.list#3.4
-    // https://eel.is/c++draft/dcl.init.aggr#3
-
     template<class T>
     auto operator()(Ti, T&&) -> aggregate_initialize_tag<I, Ti>
-        requires requires(T&& t) { { TiA{std::forward<T>(t)} }; } // emulate `Ti x[] = {std::forward<T>(t)};`
+        requires is_convertible_without_narrowing_v<T, Ti>
     {
         return {}; // silence MSVC warning
     }
@@ -282,24 +294,6 @@ struct aggregate_initialize_resolution<
 // legitimate infinite recursion errors on recursive types.
 template<class T, class... Ts>
 struct aggregate_initialize_resolution : detail::aggregate_initialize_resolution<void, T, Ts...> {};
-
-// P0870R7: is_convertible_without_narrowing
-// https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p0870r7.html
-template<class From, class To>
-struct is_convertible_without_narrowing
-    : std::false_type
-{};
-
-template<class From, class To>
-    requires
-        std::is_convertible_v<From, To> &&
-        requires { std::type_identity_t<To[]>{std::declval<From>()}; }
-struct is_convertible_without_narrowing<From, To>
-    : std::true_type
-{};
-
-template<class From, class To>
-inline constexpr bool is_convertible_without_narrowing_v = is_convertible_without_narrowing<From, To>::value;
 
 } // iris
 

--- a/include/iris/type_traits.hpp
+++ b/include/iris/type_traits.hpp
@@ -241,29 +241,6 @@ template<class From, class To>
 inline constexpr bool is_convertible_without_narrowing_v = is_convertible_without_narrowing<From, To>::value;
 
 
-// is_assignable_without_narrowing<Dest, Source>
-//
-// True when `Dest = Source` is valid AND does not involve a narrowing conversion.
-//
-// The arithmetic guard is intentional: narrowing conversions are only defined for
-// arithmetic types ([dcl.init.list]), and the underlying `is_convertible_without_narrowing`
-// uses brace-initialization (`To[]{from}`) which may select a different construction
-// path than what `is_assignable` tests (e.g. initializer_list hijacking). Restricting
-// the narrowing check to arithmetic Dest avoids false rejections for non-arithmetic
-// types where the brace-init semantics diverge from assignment semantics.
-template<class Dest, class Source>
-struct is_assignable_without_narrowing
-    : std::bool_constant<
-        std::is_assignable_v<Dest, Source> &&
-        (!std::is_arithmetic_v<std::remove_reference_t<Dest>> ||
-         is_convertible_without_narrowing_v<std::remove_cvref_t<Source>, std::remove_reference_t<Dest>>)
-    >
-{};
-
-template<class Dest, class Source>
-inline constexpr bool is_assignable_without_narrowing_v = is_assignable_without_narrowing<Dest, Source>::value;
-
-
 namespace detail {
 
 template<std::size_t I, class Ti>

--- a/include/iris/type_traits.hpp
+++ b/include/iris/type_traits.hpp
@@ -283,6 +283,24 @@ struct aggregate_initialize_resolution<
 template<class T, class... Ts>
 struct aggregate_initialize_resolution : detail::aggregate_initialize_resolution<void, T, Ts...> {};
 
+// P0870R7: is_convertible_without_narrowing
+// https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p0870r7.html
+template<class From, class To>
+struct is_convertible_without_narrowing
+    : std::false_type
+{};
+
+template<class From, class To>
+    requires
+        std::is_convertible_v<From, To> &&
+        requires { std::type_identity_t<To[]>{std::declval<From>()}; }
+struct is_convertible_without_narrowing<From, To>
+    : std::true_type
+{};
+
+template<class From, class To>
+inline constexpr bool is_convertible_without_narrowing_v = is_convertible_without_narrowing<From, To>::value;
+
 } // iris
 
 #endif

--- a/include/iris/type_traits.hpp
+++ b/include/iris/type_traits.hpp
@@ -265,17 +265,17 @@ inline constexpr bool is_convertible_without_narrowing_v = is_convertible_withou
 namespace detail {
 
 template<std::size_t I, class Ti>
-struct aggregate_initialize_tag
+struct no_narrowing_tag
 {
     static constexpr std::size_t index = I;
     using type = Ti;
 };
 
 template<std::size_t I, class Ti>
-struct aggregate_initialize_overload
+struct no_narrowing_overload
 {
     template<class T>
-    auto operator()(Ti, T&&) -> aggregate_initialize_tag<I, Ti>
+    auto operator()(Ti, T&&) -> no_narrowing_tag<I, Ti>
         requires is_convertible_without_narrowing_v<T, Ti>
     {
         return {}; // silence MSVC warning
@@ -283,27 +283,27 @@ struct aggregate_initialize_overload
 };
 
 template<class Is, class... Ts>
-struct aggregate_initialize_fun;
+struct no_narrowing_fun;
 
 // Imaginary function FUN of https://eel.is/c++draft/variant#ctor-14
 template<std::size_t... Is, class... Ts>
-struct aggregate_initialize_fun<std::index_sequence<Is...>, Ts...>
-    : aggregate_initialize_overload<Is, Ts>...
+struct no_narrowing_fun<std::index_sequence<Is...>, Ts...>
+    : no_narrowing_overload<Is, Ts>...
 {
-    using aggregate_initialize_overload<Is, Ts>::operator()...;
+    using no_narrowing_overload<Is, Ts>::operator()...;
 };
 
 template<class... Ts>
-using aggregate_initialize_fun_for = aggregate_initialize_fun<std::index_sequence_for<Ts...>, Ts...>;
+using no_narrowing_fun_for = no_narrowing_fun<std::index_sequence_for<Ts...>, Ts...>;
 
 template<class Enabled, class T, class... Ts>
-struct aggregate_initialize_resolution {};
+struct no_narrowing_resolution {};
 
 template<class T, class... Ts>
-struct aggregate_initialize_resolution<
-    std::void_t<decltype(aggregate_initialize_fun_for<Ts...>{}(std::declval<T>(), std::declval<T>()))>, T, Ts...
+struct no_narrowing_resolution<
+    std::void_t<decltype(no_narrowing_fun_for<Ts...>{}(std::declval<T>(), std::declval<T>()))>, T, Ts...
 > {
-    using tag = decltype(aggregate_initialize_fun_for<Ts...>{}(std::declval<T>(), std::declval<T>()));
+    using tag = decltype(no_narrowing_fun_for<Ts...>{}(std::declval<T>(), std::declval<T>()));
     using type = tag::type;
     static constexpr std::size_t index = tag::index;
 };
@@ -314,7 +314,7 @@ struct aggregate_initialize_resolution<
 // because they would lead to unnecessarily nested instantiation for
 // legitimate infinite recursion errors on recursive types.
 template<class T, class... Ts>
-struct aggregate_initialize_resolution : detail::aggregate_initialize_resolution<void, T, Ts...> {};
+struct no_narrowing_resolution : detail::no_narrowing_resolution<void, T, Ts...> {};
 
 } // iris
 

--- a/include/iris/type_traits.hpp
+++ b/include/iris/type_traits.hpp
@@ -225,19 +225,37 @@ constexpr bool is_trivially_swappable_v = is_trivially_swappable<T>::value;
 
 // P0870R7: is_convertible_without_narrowing
 // https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p0870r7.html
+namespace detail {
+
 template<class From, class To>
-struct is_convertible_without_narrowing
+struct is_convertible_without_narrowing_impl
     : std::false_type
+{};
+
+// void to void "conversion" is valid since `is_convertible` is defined
+// as "returning `From` is valid for function whose return type is `To`?"
+template<>
+struct is_convertible_without_narrowing_impl<void, void>
+    : std::true_type
 {};
 
 template<class From, class To>
     requires
-        std::is_convertible_v<From, To> &&
         requires (From&& x) {
             { std::type_identity_t<To[]>{std::forward<From>(x)} } -> std::same_as<To[1]>;
         }
-struct is_convertible_without_narrowing<From, To>
+struct is_convertible_without_narrowing_impl<From, To>
     : std::true_type
+{};
+
+} // namespace detail
+
+template<class From, class To>
+struct is_convertible_without_narrowing
+    : std::conjunction<
+        std::is_convertible<From, To>,
+        detail::is_convertible_without_narrowing_impl<From, To>
+    >
 {};
 
 template<class From, class To>

--- a/include/iris/type_traits.hpp
+++ b/include/iris/type_traits.hpp
@@ -10,6 +10,7 @@
 
 #include <iris/requirements.hpp>
 
+#include <concepts>
 #include <type_traits>
 #include <utility>
 
@@ -232,7 +233,9 @@ struct is_convertible_without_narrowing
 template<class From, class To>
     requires
         std::is_convertible_v<From, To> &&
-        requires { std::type_identity_t<To[]>{std::declval<From>()}; }
+        requires (From&& x) {
+            { std::type_identity_t<To[]>{std::forward<From>(x)} } -> std::same_as<To[1]>;
+        }
 struct is_convertible_without_narrowing<From, To>
     : std::true_type
 {};

--- a/include/iris/type_traits.hpp
+++ b/include/iris/type_traits.hpp
@@ -272,10 +272,10 @@ struct aggregate_initialize_tag
 };
 
 template<std::size_t I, class Ti>
-struct aggregate_initialize_overload
+struct no_narrowing_overload
 {
     template<class T>
-    auto operator()(Ti, T&&) -> aggregate_initialize_tag<I, Ti>
+    auto operator()(T&&) -> aggregate_initialize_tag<I, Ti>
         requires is_convertible_without_narrowing_v<T, Ti>
     {
         return {}; // silence MSVC warning
@@ -283,26 +283,27 @@ struct aggregate_initialize_overload
 };
 
 template<class Is, class... Ts>
-struct aggregate_initialize_fun;
+struct no_narrowing_fun;
 
 // Imaginary function FUN of https://eel.is/c++draft/variant#ctor-14
 template<std::size_t... Is, class... Ts>
-struct aggregate_initialize_fun<std::index_sequence<Is...>, Ts...>
-    : aggregate_initialize_overload<Is, Ts>...
+struct no_narrowing_fun<std::index_sequence<Is...>, Ts...>
+    : no_narrowing_overload<Is, Ts>...
 {
-    using aggregate_initialize_overload<Is, Ts>::operator()...;
+    using no_narrowing_overload<Is, Ts>::operator()...;
 };
 
 template<class... Ts>
-using aggregate_initialize_fun_for = aggregate_initialize_fun<std::index_sequence_for<Ts...>, Ts...>;
+using aggregate_initialize_fun_for = no_narrowing_fun<std::index_sequence_for<Ts...>, Ts...>;
 
 template<class Enabled, class T, class... Ts>
-struct aggregate_initialize_resolution {};
+struct no_narrowing_resolution {};
 
 template<class T, class... Ts>
-struct aggregate_initialize_resolution<
+struct no_narrowing_resolution<
     std::void_t<decltype(aggregate_initialize_fun_for<Ts...>{}(std::declval<T>(), std::declval<T>()))>, T, Ts...
-> {
+>
+{
     using tag = decltype(aggregate_initialize_fun_for<Ts...>{}(std::declval<T>(), std::declval<T>()));
     using type = tag::type;
     static constexpr std::size_t index = tag::index;
@@ -314,7 +315,7 @@ struct aggregate_initialize_resolution<
 // because they would lead to unnecessarily nested instantiation for
 // legitimate infinite recursion errors on recursive types.
 template<class T, class... Ts>
-struct aggregate_initialize_resolution : detail::aggregate_initialize_resolution<void, T, Ts...> {};
+struct no_narrowing_resolution : detail::no_narrowing_resolution<void, T, Ts...> {};
 
 } // iris
 

--- a/test/type_traits.cpp
+++ b/test/type_traits.cpp
@@ -406,6 +406,9 @@ TEST_CASE("is_convertible_without_narrowing: array and function types")
     STATIC_CHECK(iris::is_convertible_without_narrowing_v<int[3], int const*>);
     STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int*, int[3]>);
 
+    // Element types to array types
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, int[3]>);
+
     // char[] to string
     STATIC_CHECK(iris::is_convertible_without_narrowing_v<char[5], std::string>);
 

--- a/test/type_traits.cpp
+++ b/test/type_traits.cpp
@@ -86,6 +86,37 @@ TEST_CASE("is_convertible_without_narrowing")
     STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, scoped_enum>);
     STATIC_CHECK(!iris::is_convertible_without_narrowing_v<scoped_enum, int>);
     STATIC_CHECK(iris::is_convertible_without_narrowing_v<unscoped_enum, int>);
+
+    // `To[]{from}` works, but not convertible
+    {
+        {
+            struct S {
+                union {
+                    int x;
+                    float y;
+                } u;
+            };
+            [[maybe_unused]] S s{42};
+            STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, S>);
+        }
+        {
+            struct S {
+                int x[1];
+            };
+            [[maybe_unused]] S s{42};
+            STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, S>);
+        }
+        {
+            struct S {
+                struct {
+                    int x;
+                } inner;
+            };
+            [[maybe_unused]] S s{42};
+            STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, S>);
+        }
+    }
+
 }
 
 

--- a/test/type_traits.cpp
+++ b/test/type_traits.cpp
@@ -395,8 +395,8 @@ TEST_CASE("is_convertible_without_narrowing: function pointers")
     // Function pointer to bool: narrowing
     STATIC_CHECK(!iris::is_convertible_without_narrowing_v<fp, bool>);
 
-    // Function pointer to void*: not convertible (standard C++)
-    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<fp, void*>);
+    // Function pointer to void*: not allowe per standard, but MSVC accepts this conversion
+    // STATIC_CHECK(!iris::is_convertible_without_narrowing_v<fp, void*>);
 }
 
 TEST_CASE("is_convertible_without_narrowing: array and function types")

--- a/test/type_traits.cpp
+++ b/test/type_traits.cpp
@@ -19,7 +19,73 @@ struct n_tuple;
 template<int... Ns>
 struct n_list;
 
+struct convertible_from_int {
+    convertible_from_int(int);
+};
+
+struct not_convertible_from_int {};
+
+enum class scoped_enum {};
+enum unscoped_enum {};
+
 } // anonymous
+
+
+TEST_CASE("is_convertible_without_narrowing")
+{
+    // Same type: always OK
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<int, int>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<double, double>);
+
+    // Widening integer conversions: OK
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<int, long long>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<short, int>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<char, int>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<unsigned, unsigned long>);
+
+    // Narrowing integer conversions: rejected
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<long long, int>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, short>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, char>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<unsigned long, unsigned>);
+
+    // Floating-point widening: OK
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<float, double>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<float, long double>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<double, long double>);
+
+    // Floating-point narrowing: rejected
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<double, float>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<long double, double>);
+
+    // Integer to floating-point: narrowing
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, float>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<long long, double>);
+
+    // Floating-point to integer: narrowing
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<float, int>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<double, int>);
+
+    // Signed/unsigned mismatch
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, unsigned>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<unsigned, int>);
+
+    // Bool conversions
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<bool, int>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, bool>);
+
+    // User-defined implicit conversion: OK (no narrowing concern)
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<int, convertible_from_int>);
+
+    // Not convertible at all
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, not_convertible_from_int>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, std::string>);
+
+    // Enum conversions
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, scoped_enum>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<scoped_enum, int>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<unscoped_enum, int>);
+}
 
 
 TEST_CASE("specialization_of")

--- a/test/type_traits.cpp
+++ b/test/type_traits.cpp
@@ -33,16 +33,6 @@ struct explicit_from_int
     explicit_from_int& operator=(int) { return *this; }
 };
 
-// "Broken" implementation: is_assignable_without_narrowing without the arithmetic guard.
-// This demonstrates why the guard is needed.
-template<class Dest, class Source>
-struct broken_is_assignable_without_narrowing
-    : std::bool_constant<
-        std::is_assignable_v<Dest, Source> &&
-        iris::is_convertible_without_narrowing_v<std::remove_cvref_t<Source>, std::remove_reference_t<Dest>>
-    >
-{};
-
 enum class scoped_enum {};
 enum unscoped_enum {};
 

--- a/test/type_traits.cpp
+++ b/test/type_traits.cpp
@@ -19,7 +19,8 @@ struct n_tuple;
 template<int... Ns>
 struct n_list;
 
-struct convertible_from_int {
+struct convertible_from_int
+{
     convertible_from_int(int);
 };
 

--- a/test/type_traits.cpp
+++ b/test/type_traits.cpp
@@ -26,6 +26,23 @@ struct convertible_from_int
 
 struct not_convertible_from_int {};
 
+struct explicit_from_int
+{
+    explicit explicit_from_int() = default;
+    explicit explicit_from_int(int);
+    explicit_from_int& operator=(int) { return *this; }
+};
+
+// "Broken" implementation: is_assignable_without_narrowing without the arithmetic guard.
+// This demonstrates why the guard is needed.
+template<class Dest, class Source>
+struct broken_is_assignable_without_narrowing
+    : std::bool_constant<
+        std::is_assignable_v<Dest, Source> &&
+        iris::is_convertible_without_narrowing_v<std::remove_cvref_t<Source>, std::remove_reference_t<Dest>>
+    >
+{};
+
 enum class scoped_enum {};
 enum unscoped_enum {};
 
@@ -149,6 +166,18 @@ TEST_CASE("is_assignable_without_narrowing")
     // Not assignable at all
     STATIC_CHECK(!iris::is_assignable_without_narrowing_v<not_convertible_from_int&, int>);
     STATIC_CHECK(!iris::is_assignable_without_narrowing_v<int&, std::string>);
+
+    // Non-arithmetic dest with explicit ctor + assignment operator.
+    // Without the arithmetic guard, is_assignable_without_narrowing would
+    // incorrectly return false because is_convertible_without_narrowing
+    // rejects explicit conversions (brace-init uses copy-list-init).
+    STATIC_CHECK(std::is_assignable_v<explicit_from_int&, int>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, explicit_from_int>);
+    STATIC_CHECK(iris::is_assignable_without_narrowing_v<explicit_from_int&, int>);
+
+    // Verify the "false" implementation (without arithmetic guard) breaks here:
+    // it incorrectly rejects this valid, non-narrowing assignment.
+    STATIC_CHECK(!broken_is_assignable_without_narrowing<explicit_from_int&, int>::value);
 }
 
 

--- a/test/type_traits.cpp
+++ b/test/type_traits.cpp
@@ -120,6 +120,38 @@ TEST_CASE("is_convertible_without_narrowing")
 }
 
 
+TEST_CASE("is_assignable_without_narrowing")
+{
+    // Non-narrowing: same type
+    STATIC_CHECK(iris::is_assignable_without_narrowing_v<int&, int>);
+    STATIC_CHECK(iris::is_assignable_without_narrowing_v<double&, double>);
+
+    // Non-narrowing: widening
+    STATIC_CHECK(iris::is_assignable_without_narrowing_v<long long&, int>);
+    STATIC_CHECK(iris::is_assignable_without_narrowing_v<double&, float>);
+    STATIC_CHECK(iris::is_assignable_without_narrowing_v<int&, short>);
+
+    // Narrowing: lossy conversions
+    STATIC_CHECK(!iris::is_assignable_without_narrowing_v<int&, long long>);
+    STATIC_CHECK(!iris::is_assignable_without_narrowing_v<short&, int>);
+    STATIC_CHECK(!iris::is_assignable_without_narrowing_v<float&, double>);
+    STATIC_CHECK(!iris::is_assignable_without_narrowing_v<int&, float>);
+    STATIC_CHECK(!iris::is_assignable_without_narrowing_v<float&, int>);
+
+    // Signed/unsigned mismatch
+    STATIC_CHECK(!iris::is_assignable_without_narrowing_v<int&, unsigned>);
+    STATIC_CHECK(!iris::is_assignable_without_narrowing_v<unsigned&, int>);
+
+    // Non-arithmetic dest: narrowing not checked (trusts user-defined conversion)
+    STATIC_CHECK(iris::is_assignable_without_narrowing_v<std::string&, const char*>);
+    STATIC_CHECK(iris::is_assignable_without_narrowing_v<convertible_from_int&, int>);
+
+    // Not assignable at all
+    STATIC_CHECK(!iris::is_assignable_without_narrowing_v<not_convertible_from_int&, int>);
+    STATIC_CHECK(!iris::is_assignable_without_narrowing_v<int&, std::string>);
+}
+
+
 TEST_CASE("specialization_of")
 {
     STATIC_CHECK(iris::is_ttp_specialization_of_v<tuple<>, tuple>);

--- a/test/type_traits.cpp
+++ b/test/type_traits.cpp
@@ -137,50 +137,6 @@ TEST_CASE("is_convertible_without_narrowing")
 }
 
 
-TEST_CASE("is_assignable_without_narrowing")
-{
-    // Non-narrowing: same type
-    STATIC_CHECK(iris::is_assignable_without_narrowing_v<int&, int>);
-    STATIC_CHECK(iris::is_assignable_without_narrowing_v<double&, double>);
-
-    // Non-narrowing: widening
-    STATIC_CHECK(iris::is_assignable_without_narrowing_v<long long&, int>);
-    STATIC_CHECK(iris::is_assignable_without_narrowing_v<double&, float>);
-    STATIC_CHECK(iris::is_assignable_without_narrowing_v<int&, short>);
-
-    // Narrowing: lossy conversions
-    STATIC_CHECK(!iris::is_assignable_without_narrowing_v<int&, long long>);
-    STATIC_CHECK(!iris::is_assignable_without_narrowing_v<short&, int>);
-    STATIC_CHECK(!iris::is_assignable_without_narrowing_v<float&, double>);
-    STATIC_CHECK(!iris::is_assignable_without_narrowing_v<int&, float>);
-    STATIC_CHECK(!iris::is_assignable_without_narrowing_v<float&, int>);
-
-    // Signed/unsigned mismatch
-    STATIC_CHECK(!iris::is_assignable_without_narrowing_v<int&, unsigned>);
-    STATIC_CHECK(!iris::is_assignable_without_narrowing_v<unsigned&, int>);
-
-    // Non-arithmetic dest: narrowing not checked (trusts user-defined conversion)
-    STATIC_CHECK(iris::is_assignable_without_narrowing_v<std::string&, const char*>);
-    STATIC_CHECK(iris::is_assignable_without_narrowing_v<convertible_from_int&, int>);
-
-    // Not assignable at all
-    STATIC_CHECK(!iris::is_assignable_without_narrowing_v<not_convertible_from_int&, int>);
-    STATIC_CHECK(!iris::is_assignable_without_narrowing_v<int&, std::string>);
-
-    // Non-arithmetic dest with explicit ctor + assignment operator.
-    // Without the arithmetic guard, is_assignable_without_narrowing would
-    // incorrectly return false because is_convertible_without_narrowing
-    // rejects explicit conversions (brace-init uses copy-list-init).
-    STATIC_CHECK(std::is_assignable_v<explicit_from_int&, int>);
-    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, explicit_from_int>);
-    STATIC_CHECK(iris::is_assignable_without_narrowing_v<explicit_from_int&, int>);
-
-    // Verify the "false" implementation (without arithmetic guard) breaks here:
-    // it incorrectly rejects this valid, non-narrowing assignment.
-    STATIC_CHECK(!broken_is_assignable_without_narrowing<explicit_from_int&, int>::value);
-}
-
-
 TEST_CASE("specialization_of")
 {
     STATIC_CHECK(iris::is_ttp_specialization_of_v<tuple<>, tuple>);

--- a/test/type_traits.cpp
+++ b/test/type_traits.cpp
@@ -35,95 +35,384 @@ struct explicit_from_int
 
 enum class scoped_enum {};
 enum unscoped_enum {};
+enum class scoped_enum_uint8 : unsigned char {};
+enum unscoped_enum_short : short {};
+
+struct base {};
+struct derived : base {};
+
+struct implicit_conversion_op
+{
+    operator int() const;
+};
+
+struct explicit_conversion_op
+{
+    explicit operator int() const;
+};
+
+struct abstract_class
+{
+    virtual void f() = 0;
+};
+
+struct multi_arg_implicit
+{
+    multi_arg_implicit(int, double);
+};
+
+struct has_initializer_list_ctor
+{
+    has_initializer_list_ctor(std::initializer_list<int>);
+};
+
+struct member_ptr_test
+{
+    int member;
+    void func();
+};
 
 } // anonymous
 
 
-TEST_CASE("is_convertible_without_narrowing")
+TEST_CASE("is_convertible_without_narrowing: same type identity")
 {
-    // Same type: always OK
     STATIC_CHECK(iris::is_convertible_without_narrowing_v<int, int>);
     STATIC_CHECK(iris::is_convertible_without_narrowing_v<double, double>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<float, float>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<bool, bool>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<char, char>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<signed char, signed char>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<unsigned char, unsigned char>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<wchar_t, wchar_t>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<char8_t, char8_t>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<char16_t, char16_t>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<char32_t, char32_t>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<short, short>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<unsigned short, unsigned short>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<long, long>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<unsigned long, unsigned long>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<long long, long long>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<unsigned long long, unsigned long long>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<long double, long double>);
+}
 
-    // Widening integer conversions: OK
-    STATIC_CHECK(iris::is_convertible_without_narrowing_v<int, long long>);
+TEST_CASE("is_convertible_without_narrowing: integer widening")
+{
     STATIC_CHECK(iris::is_convertible_without_narrowing_v<short, int>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<short, long>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<short, long long>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<int, long long>);
     STATIC_CHECK(iris::is_convertible_without_narrowing_v<char, int>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<signed char, int>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<unsigned char, int>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<unsigned char, unsigned int>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<unsigned short, unsigned int>);
     STATIC_CHECK(iris::is_convertible_without_narrowing_v<unsigned, unsigned long long>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<unsigned short, unsigned long long>);
+}
 
-    // Narrowing integer conversions: rejected
+TEST_CASE("is_convertible_without_narrowing: integer narrowing")
+{
     STATIC_CHECK(!iris::is_convertible_without_narrowing_v<long long, int>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<long long, short>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<long long, char>);
     STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, short>);
     STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, char>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, signed char>);
     STATIC_CHECK(!iris::is_convertible_without_narrowing_v<unsigned long long, unsigned>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<unsigned int, unsigned short>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<unsigned int, unsigned char>);
+}
 
-    // Floating-point widening: OK
+TEST_CASE("is_convertible_without_narrowing: signed/unsigned mismatch")
+{
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, unsigned>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<unsigned, int>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<long, unsigned long>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<unsigned long, long>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<long long, unsigned long long>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<unsigned long long, long long>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<short, unsigned short>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<unsigned short, short>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<signed char, unsigned char>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<unsigned char, signed char>);
+}
+
+TEST_CASE("is_convertible_without_narrowing: floating-point widening")
+{
     STATIC_CHECK(iris::is_convertible_without_narrowing_v<float, double>);
     STATIC_CHECK(iris::is_convertible_without_narrowing_v<float, long double>);
     STATIC_CHECK(iris::is_convertible_without_narrowing_v<double, long double>);
+}
 
-    // Floating-point narrowing: rejected
+TEST_CASE("is_convertible_without_narrowing: floating-point narrowing")
+{
     STATIC_CHECK(!iris::is_convertible_without_narrowing_v<double, float>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<long double, float>);
     STATIC_CHECK(!iris::is_convertible_without_narrowing_v<long double, double>);
+}
 
+TEST_CASE("is_convertible_without_narrowing: integer/floating-point cross")
+{
     // Integer to floating-point: narrowing
     STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, float>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, double>);
     STATIC_CHECK(!iris::is_convertible_without_narrowing_v<long long, double>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<unsigned long long, double>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<long, float>);
 
     // Floating-point to integer: narrowing
     STATIC_CHECK(!iris::is_convertible_without_narrowing_v<float, int>);
     STATIC_CHECK(!iris::is_convertible_without_narrowing_v<double, int>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<long double, int>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<float, long long>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<double, short>);
+}
 
-    // Signed/unsigned mismatch
-    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, unsigned>);
-    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<unsigned, int>);
+TEST_CASE("is_convertible_without_narrowing: bool")
+{
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<bool, bool>);
 
-    // Bool conversions
+    // bool to integer: widening (bool is an integer type with rank < int)
     STATIC_CHECK(iris::is_convertible_without_narrowing_v<bool, int>);
-    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, bool>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<bool, long long>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<bool, unsigned>);
 
-    // User-defined implicit conversion: OK (no narrowing concern)
+    // Integer/float to bool: narrowing
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, bool>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<char, bool>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<double, bool>);
+}
+
+TEST_CASE("is_convertible_without_narrowing: char types")
+{
+    // char8_t, char16_t, char32_t are distinct types with specific widths
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<char16_t, char8_t>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<char32_t, char16_t>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<char32_t, char8_t>);
+
+    // wchar_t cross: platform-dependent (wchar_t width varies)
+    // On platforms where sizeof(wchar_t) == sizeof(int), these may be non-narrowing.
+
+    // char to int: widening
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<char, int>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<signed char, int>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<unsigned char, int>);
+
+    // int to char: narrowing
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, char>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, signed char>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, unsigned char>);
+}
+
+TEST_CASE("is_convertible_without_narrowing: enum types")
+{
+    // Scoped enums: not implicitly convertible to/from anything
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<scoped_enum, int>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, scoped_enum>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<scoped_enum, scoped_enum_uint8>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<scoped_enum_uint8, scoped_enum>);
+
+    // Unscoped enums: implicitly convertible to integer types
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<unscoped_enum, int>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<unscoped_enum, long long>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, unscoped_enum>);
+
+    // Unscoped enum with fixed underlying type (short)
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<unscoped_enum_short, int>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<unscoped_enum_short, long long>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, unscoped_enum_short>);
+}
+
+TEST_CASE("is_convertible_without_narrowing: pointer types")
+{
+    // Same pointer type
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<int*, int*>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<void*, void*>);
+
+    // Derived-to-base pointer conversion
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<derived*, base*>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<base*, derived*>);
+
+    // T* to void*
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<int*, void*>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<base*, void*>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<void*, int*>);
+
+    // Adding const via pointer
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<int*, const int*>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<const int*, int*>);
+
+    // nullptr_t
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<std::nullptr_t, int*>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<std::nullptr_t, const void*>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int*, std::nullptr_t>);
+
+    // pointer to bool: narrowing (all pointers/nullptr to bool is narrowing)
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<std::nullptr_t, bool>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int*, bool>);
+
+    // Pointer to/from arithmetic: not convertible
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int*, int>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, int*>);
+
+    // Pointer-to-member
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<int member_ptr_test::*, int member_ptr_test::*>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int member_ptr_test::*, int*>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int*, int member_ptr_test::*>);
+
+    // Member function pointer
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<void (member_ptr_test::*)(), int>);
+}
+
+TEST_CASE("is_convertible_without_narrowing: class types with implicit ctor")
+{
+    // Implicit converting constructor
     STATIC_CHECK(iris::is_convertible_without_narrowing_v<int, convertible_from_int>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<convertible_from_int, int>);
 
     // Not convertible at all
     STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, not_convertible_from_int>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<not_convertible_from_int, int>);
     STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, std::string>);
+}
 
-    // Enum conversions
-    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, scoped_enum>);
-    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<scoped_enum, int>);
-    STATIC_CHECK(iris::is_convertible_without_narrowing_v<unscoped_enum, int>);
+TEST_CASE("is_convertible_without_narrowing: class types with explicit ctor")
+{
+    // Explicit ctor: is_convertible is false, so trait is false
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, explicit_from_int>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<explicit_from_int, int>);
+}
 
-    // `To[]{from}` works, but not convertible
+TEST_CASE("is_convertible_without_narrowing: class types with conversion operator")
+{
+    // Implicit conversion operator
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<implicit_conversion_op, int>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, implicit_conversion_op>);
+
+    // Explicit conversion operator: is_convertible is false
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<explicit_conversion_op, int>);
+}
+
+TEST_CASE("is_convertible_without_narrowing: class types inheritance")
+{
+    // Derived to base (by value): implicitly convertible
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<derived, base>);
+    // Base to derived: not implicitly convertible
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<base, derived>);
+
+    // Derived& to base: implicitly convertible
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<derived&, base>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<const derived&, base>);
+}
+
+TEST_CASE("is_convertible_without_narrowing: aggregate types")
+{
+    // Aggregates with brace-init but no implicit conversion
     {
-        {
-            struct S {
-                union {
-                    int x;
-                    float y;
-                } u;
-            };
-            [[maybe_unused]] S s{42};
-            STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, S>);
-        }
-        {
-            struct S {
-                int x[1];
-            };
-            [[maybe_unused]] S s{42};
-            STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, S>);
-        }
-        {
-            struct S {
-                struct {
-                    int x;
-                } inner;
-            };
-            [[maybe_unused]] S s{42};
-            STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, S>);
-        }
+        struct S {
+            union {
+                int x;
+                float y;
+            } u;
+        };
+        [[maybe_unused]] S s{42};
+        STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, S>);
     }
+    {
+        struct S {
+            int x[1];
+        };
+        [[maybe_unused]] S s{42};
+        STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, S>);
+    }
+    {
+        struct S {
+            struct {
+                int x;
+            } inner;
+        };
+        [[maybe_unused]] S s{42};
+        STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, S>);
+    }
+    {
+        struct S {
+            int x;
+            double y;
+        };
+        STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, S>);
+        STATIC_CHECK(!iris::is_convertible_without_narrowing_v<S, int>);
+    }
+}
 
+TEST_CASE("is_convertible_without_narrowing: void")
+{
+    // void to void: is_convertible_v<void, void> is true per the standard.
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<void, void>);
+
+    // void to/from anything else: not convertible
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<void, int>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, void>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<void, base>);
+}
+
+TEST_CASE("is_convertible_without_narrowing: cv-qualified types")
+{
+    // const arithmetic: same narrowing rules
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<const int, int>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<int, const int>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<const int, long long>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<const long long, int>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<volatile int, int>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<const volatile int, int>);
+}
+
+TEST_CASE("is_convertible_without_narrowing: reference types as From")
+{
+    // Lvalue reference
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<int&, int>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<const int&, int>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<int&, long long>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<long long&, int>);
+
+    // Rvalue reference
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<int&&, int>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<int&&, long long>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<long long&&, int>);
+}
+
+TEST_CASE("is_convertible_without_narrowing: function pointers")
+{
+    using fp = void(*)();
+    using fp2 = int(*)(double);
+
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<fp, fp>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<fp, fp2>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<fp, int>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, fp>);
+
+    // Function pointer to bool: narrowing
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<fp, bool>);
+
+    // Function pointer to void*: not convertible (standard C++)
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<fp, void*>);
+}
+
+TEST_CASE("is_convertible_without_narrowing: array and function types")
+{
+    // Array types as From decay to pointers
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<int[3], int*>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<int[3], const int*>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int*, int[3]>);
+
+    // char[] to string
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<char[5], std::string>);
+
+    // Function type decays to function pointer
+    using fn = void();
+    using fnp = void(*)();
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<fn, fnp>);
 }
 
 

--- a/test/type_traits.cpp
+++ b/test/type_traits.cpp
@@ -42,13 +42,13 @@ TEST_CASE("is_convertible_without_narrowing")
     STATIC_CHECK(iris::is_convertible_without_narrowing_v<int, long long>);
     STATIC_CHECK(iris::is_convertible_without_narrowing_v<short, int>);
     STATIC_CHECK(iris::is_convertible_without_narrowing_v<char, int>);
-    STATIC_CHECK(iris::is_convertible_without_narrowing_v<unsigned, unsigned long>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<unsigned, unsigned long long>);
 
     // Narrowing integer conversions: rejected
     STATIC_CHECK(!iris::is_convertible_without_narrowing_v<long long, int>);
     STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, short>);
     STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int, char>);
-    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<unsigned long, unsigned>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<unsigned long long, unsigned>);
 
     // Floating-point widening: OK
     STATIC_CHECK(iris::is_convertible_without_narrowing_v<float, double>);

--- a/test/type_traits.cpp
+++ b/test/type_traits.cpp
@@ -241,12 +241,12 @@ TEST_CASE("is_convertible_without_narrowing: pointer types")
     STATIC_CHECK(!iris::is_convertible_without_narrowing_v<void*, int*>);
 
     // Adding const via pointer
-    STATIC_CHECK(iris::is_convertible_without_narrowing_v<int*, const int*>);
-    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<const int*, int*>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<int*, int const*>);
+    STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int const*, int*>);
 
     // nullptr_t
     STATIC_CHECK(iris::is_convertible_without_narrowing_v<std::nullptr_t, int*>);
-    STATIC_CHECK(iris::is_convertible_without_narrowing_v<std::nullptr_t, const void*>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<std::nullptr_t, void const*>);
     STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int*, std::nullptr_t>);
 
     // pointer to bool: narrowing (all pointers/nullptr to bool is narrowing)
@@ -372,7 +372,7 @@ TEST_CASE("is_convertible_without_narrowing: reference types as From")
 {
     // Lvalue reference
     STATIC_CHECK(iris::is_convertible_without_narrowing_v<int&, int>);
-    STATIC_CHECK(iris::is_convertible_without_narrowing_v<const int&, int>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<int const&, int>);
     STATIC_CHECK(iris::is_convertible_without_narrowing_v<int&, long long>);
     STATIC_CHECK(!iris::is_convertible_without_narrowing_v<long long&, int>);
 
@@ -403,7 +403,7 @@ TEST_CASE("is_convertible_without_narrowing: array and function types")
 {
     // Array types as From decay to pointers
     STATIC_CHECK(iris::is_convertible_without_narrowing_v<int[3], int*>);
-    STATIC_CHECK(iris::is_convertible_without_narrowing_v<int[3], const int*>);
+    STATIC_CHECK(iris::is_convertible_without_narrowing_v<int[3], int const*>);
     STATIC_CHECK(!iris::is_convertible_without_narrowing_v<int*, int[3]>);
 
     // char[] to string


### PR DESCRIPTION
fixes #5

The array form `To[]` is specifically chosen over the simpler `To{from}` because the latter can accidentally select aggregate initialization of `To` itself (if `To` is an aggregate) or match a constructor taking `std::initializer_list`, both of
   which would mask the actual narrowing behavior. Since `To[]` is always an aggregate regardless of what `To` is, the braced initialization applies uniformly to the element type and tests exactly what we want: whether `From` can be
  copy-initialized into a `To` slot without narrowing.