### PR TITLE
Add `ordinary_normalize`

### DIFF
--- a/include/iris/stdint.hpp
+++ b/include/iris/stdint.hpp
@@ -98,7 +98,7 @@ using make_integer_of_size_impl_t = integer_of_size_impl<signedness_of_integral<
 template<class T>
 struct make_signed_of_size
 {
-    static_assert(std::integral<T> && !std::same_as<std::remove_cv_t<T>, bool> || std::is_enum_v<T>);
+    static_assert((std::integral<T> && !std::same_as<std::remove_cv_t<T>, bool>) || std::is_enum_v<T>);
     using type = remove_cv<T>::template apply<detail::make_signed_of_size_impl_t>;
 };
 
@@ -108,7 +108,7 @@ using make_signed_of_size_t = make_signed_of_size<T>::type;
 template<class T>
 struct make_unsigned_of_size
 {
-    static_assert(std::integral<T> && !std::same_as<std::remove_cv_t<T>, bool> || std::is_enum_v<T>);
+    static_assert((std::integral<T> && !std::same_as<std::remove_cv_t<T>, bool>) || std::is_enum_v<T>);
     using type = remove_cv<T>::template apply<detail::make_unsigned_of_size_impl_t>;
 };
 
@@ -118,7 +118,7 @@ using make_unsigned_of_size_t = make_unsigned_of_size<T>::type;
 template<class T>
 struct make_integer_of_size
 {
-    static_assert(std::integral<T> && !std::same_as<std::remove_cv_t<T>, bool> || std::is_enum_v<T>);
+    static_assert((std::integral<T> && !std::same_as<std::remove_cv_t<T>, bool>) || std::is_enum_v<T>);
     using type = remove_cv<T>::template apply<detail::make_integer_of_size_impl_t>;
 };
 

--- a/include/iris/string_algo.hpp
+++ b/include/iris/string_algo.hpp
@@ -3,13 +3,16 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <iris/config.hpp>
-#include <iris/string.hpp>
+#include <iris/config.hpp> // IWYU pragma: keep
+#include <iris/string.hpp> // IWYU pragma: keep
+#include <iris/stdint.hpp>
 
+#include <concepts>
 #include <string>
 #include <string_view>
 #include <algorithm>
 #include <type_traits>
+#include <array>
 
 #include <cassert>
 
@@ -263,6 +266,118 @@ template<int = 0>
 {
     std::u32string buf(input);
     iris::unescape(buf, leader);
+    return buf;
+}
+
+
+namespace detail {
+
+// Closed range [first, last] of character set
+template<class CharT>
+struct char_range
+{
+    using char_type = CharT;
+    using value_type = make_unsigned_of_size_t<CharT>;
+
+    CharT first, last;
+
+    consteval char_range(CharT first, CharT last)
+        : first(first)
+        , last(last)
+    {
+        if (first > last) throw std::domain_error{"char_range must be proper"};
+    }
+
+    [[nodiscard]] constexpr std::size_t count() const noexcept
+    {
+        return static_cast<std::size_t>(
+            static_cast<value_type>(last) - static_cast<value_type>(first)
+        ) + 1uz;
+    }
+};
+
+template<class FromT, class ToT = FromT>
+struct char_substitute
+{
+    using char_type = FromT::char_type;
+    using value_type = make_unsigned_of_size_t<char_type>;
+
+    FromT from;
+    ToT to;
+
+    consteval char_substitute(FromT from, ToT to)
+        : from(from)
+        , to(to)
+    {
+        if (from.count() != to.count()) {
+            throw std::out_of_range{"from.count() does not match to.count()"};
+        }
+    }
+
+    [[nodiscard]] constexpr bool substitute(char_type& ch) const noexcept
+    {
+        if (from.first <= ch && ch <= from.last) {
+            value_type const ofs = static_cast<value_type>(ch) - static_cast<value_type>(from.first);
+            ch = static_cast<char_type>(static_cast<value_type>(to.first) + ofs);
+            return true;
+        }
+        return false;
+    }
+};
+
+template<class CharT>
+inline constexpr auto jp_substitutes = std::to_array<char_substitute<char_range<CharT>>>({
+    {{U'０', U'９'}, {U'0', U'9'}},
+    {{U'Ａ', U'Ｚ'}, {U'A', U'Z'}},
+    {{U'ａ', U'ｚ'}, {U'a', U'z'}},
+});
+
+} // detail
+
+// Normalizes occurrences of "ordinary" inconsistent spelling with
+// the canonicalized letter.
+//
+// This algorithm guarantees the character count never changes regardless
+// of the transformation, in contrast to fully-featured Unicode normalization
+// such as NFKC. (Note: NFKC not only changes the character count; it may
+// occasionally render the resulting character to empty set, or even *flips*
+// the character positioning, which makes it require a rather complex algo.)
+//
+// The above design choice enables this function to be used like an *easy*
+// canonicalization, where the original and the transformed string can both
+// be mapped to the identical `interval<int>`.
+template<class CharT, class TraitsT>
+constexpr void ordinary_normalize(std::basic_string<CharT, TraitsT>& input)
+{
+    static_assert(std::same_as<CharT, char32_t>, "sorry, not implemented");
+
+    for (CharT& ch : input) {
+        switch (ch) {
+        case U'　': ch = U' '; continue;
+        default: break;
+        }
+
+        for (auto const& subs : detail::jp_substitutes<CharT>) {
+            if (subs.substitute(ch)) {
+                break;
+            }
+        }
+    }
+}
+
+//template<int = 0>
+//[[nodiscard]] constexpr std::string ordinary_normalize_copy(std::string_view input)
+//{
+//    std::string buf(input);
+//    iris::ordinary_normalize(buf);
+//    return buf;
+//}
+
+template<int = 0>
+[[nodiscard]] constexpr std::u32string ordinary_normalize_copy(std::u32string_view input)
+{
+    std::u32string buf(input);
+    iris::ordinary_normalize(buf);
     return buf;
 }
 

--- a/test/string_algo.cpp
+++ b/test/string_algo.cpp
@@ -205,4 +205,66 @@ TEST_CASE("string_algo: escape")
 #undef IRIS_TEST_ESCAPE
 }
 
+TEST_CASE("string_algo: ordinary_normalize")
+{
+#ifdef _MSC_VER
+    SetConsoleOutputCP(CP_UTF8);
+#endif
+
+    {
+        std::u32string str;
+        iris::ordinary_normalize(str);
+        CHECK(str == U""sv);
+    }
+
+    CHECK(iris::ordinary_normalize_copy(U"") == U""sv);
+
+#if 0
+let edge_chars = [['ａ', 'ｚ'], ['Ａ', 'Ｚ'], ['０', '９']];
+for (let char_range of edge_chars) {
+    console.log(`[${char_range[0].codePointAt(0).toString(16)}, ${char_range[1].codePointAt(0).toString(16)}]`);
+}
+// [ff41, ff5a]
+// [ff21, ff3a]
+// [ff10, ff19]
+#endif
+
+    CHECK(iris::ordinary_normalize_copy(U" ") == U" "sv);
+    CHECK(iris::ordinary_normalize_copy(U"　") == U" "sv);
+
+    CHECK(iris::ordinary_normalize_copy(U"a") == U"a"sv);
+    CHECK(iris::ordinary_normalize_copy(U"z") == U"z"sv);
+    CHECK(iris::ordinary_normalize_copy(U"A") == U"A"sv);
+    CHECK(iris::ordinary_normalize_copy(U"Z") == U"Z"sv);
+    CHECK(iris::ordinary_normalize_copy(U"0") == U"0"sv);
+    CHECK(iris::ordinary_normalize_copy(U"9") == U"9"sv);
+
+    CHECK(iris::ordinary_normalize_copy(U"ａ") == U"a"sv);
+    CHECK(iris::ordinary_normalize_copy(U"ｚ") == U"z"sv);
+    CHECK(iris::ordinary_normalize_copy(U"\uff5b") == U"\uff5b"sv);
+
+    CHECK(iris::ordinary_normalize_copy(U"Ａ") == U"A"sv);
+    CHECK(iris::ordinary_normalize_copy(U"Ｚ") == U"Z"sv);
+    CHECK(iris::ordinary_normalize_copy(U"\uff3b") == U"\uff3b"sv);
+
+    CHECK(iris::ordinary_normalize_copy(U"０") == U"0"sv);
+    CHECK(iris::ordinary_normalize_copy(U"９") == U"9"sv);
+    CHECK(iris::ordinary_normalize_copy(U"\uff20") == U"\uff20"sv);
+
+    {
+        std::u32string_view const input =
+            U"ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ／"
+            U"ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺ／"
+            U"０１２３４５６７８９";
+
+        std::u32string_view const expected_normalized =
+            U"abcdefghijklmnopqrstuvwxyz／"
+            U"ABCDEFGHIJKLMNOPQRSTUVWXYZ／"
+            U"0123456789";
+
+        CHECK(iris::ordinary_normalize_copy(input) == expected_normalized);
+        CHECK(iris::ordinary_normalize_copy(input).size() == input.size());
+    }
+}
+
 // NOLINTEND(readability-container-size-empty)


### PR DESCRIPTION
```cpp
// Normalizes occurrences of "ordinary" inconsistent spelling with
// the canonicalized letter.
//
// This algorithm guarantees the character count never changes regardless
// of the transformation, in contrast to fully-featured Unicode normalization
// such as NFKC. (Note: NFKC not only changes the character count; it may
// occasionally render the resulting character to empty set, or even *flips*
// the character positioning, which makes it require a rather complex algo.)
//
// The above design choice enables this function to be used like an *easy*
// canonicalization, where the original and the transformed string can both
// be mapped to the identical `interval<int>`.
```